### PR TITLE
Remove the output file before creating the parallel port

### DIFF
--- a/samples/vsphere/vcenter/vm/hardware/parallel.py
+++ b/samples/vsphere/vcenter/vm/hardware/parallel.py
@@ -103,6 +103,9 @@ def run():
         print('vm.hardware.Parallel.get({}, {}) -> {}'.format(vm, parallel, pp(
             parallel_info)))
 
+    # Make sure output file doesn't exist already
+    cleanup_backends()
+
     print('\n# Example: Create Parallel port with defaults')
     parallel_create_spec = Parallel.CreateSpec()
     parallel = parallel_svc.create(vm, parallel_create_spec)
@@ -180,6 +183,9 @@ def run():
     print('vm.hardware.Parallel.list({}) -> {}'.
           format(vm, parallel_summaries))
 
+    # Always cleanup output file so the VM can be powered on next time
+    cleanup_backends()
+
 
 def cleanup():
     print('\n# Cleanup: Delete VM Parallel ports that were added')
@@ -192,8 +198,6 @@ def cleanup():
     if set(orig_parallel_summaries) != set(parallel_summaries):
         print('vm.hardware.Parallel WARNING: '
               'Final Parallel ports info does not match original')
-
-    cleanup_backends()
 
 
 def cleanup_backends():

--- a/samples/vsphere/vcenter/vm/hardware/serial.py
+++ b/samples/vsphere/vcenter/vm/hardware/serial.py
@@ -214,6 +214,9 @@ def run():
     serial_summaries = serial_svc.list(vm=vm)
     print('vm.hardware.Serial.list({}) -> {}'.format(vm, serial_summaries))
 
+    # Always cleanup output file so the VM can be powered on next time
+    cleanup_backends()
+
 
 def cleanup():
     print('\n# Delete VM Serial ports that were added')
@@ -226,8 +229,6 @@ def cleanup():
     if set(orig_serial_summaries) != set(serial_summaries):
         print('vm.hardware.Serial WARNING: '
               'Final Serial ports info does not match original')
-
-    cleanup_backends()
 
 
 def cleanup_backends():


### PR DESCRIPTION
Need to make the same fix as the one in #13 for parallel port.
Also move the cleanup_backends to the main sample run to make
sure the output file is always deleted.

Signed-off-by: Tianhao He <tianhao64@users.noreply.github.com>