### PR TITLE
Update configuration inputs

### DIFF
--- a/samples/vsphere/vcenter/vm/create/create_basic_vm.py
+++ b/samples/vsphere/vcenter/vm/create/create_basic_vm.py
@@ -42,7 +42,6 @@ Sample Prerequisites:
     - datacenter
     - vm folder
     - datastore
-    - cluster
     - standard switch network
 """
 
@@ -70,9 +69,9 @@ def setup(context=None):
 
 def run():
     # Get a placement spec
-    datacenter_name = testbed.config['DATACENTER2_NAME']
+    datacenter_name = testbed.config['VM_DATACENTER_NAME']
     vm_folder_name = testbed.config['VM_FOLDER2_NAME']
-    datastore_name = testbed.config['NFS_DATASTORE_NAME']
+    datastore_name = testbed.config['VM_DATASTORE_NAME']
     std_portgroup_name = testbed.config['STDPORTGROUP_NAME']
     placement_spec = vm_placement_helper.get_placement_spec_for_resource_pool(
         stub_config,

--- a/samples/vsphere/vcenter/vm/create/create_default_vm.py
+++ b/samples/vsphere/vcenter/vm/create/create_default_vm.py
@@ -36,8 +36,6 @@ Sample Prerequisites:
     - datacenter
     - vm folder
     - datastore
-    - cluster
-    - standard switch network
 """
 
 stub_config = None
@@ -64,9 +62,9 @@ def setup(context=None):
 
 def run():
     # Get a placement spec
-    datacenter_name = testbed.config['DATACENTER2_NAME']
+    datacenter_name = testbed.config['VM_DATACENTER_NAME']
     vm_folder_name = testbed.config['VM_FOLDER2_NAME']
-    datastore_name = testbed.config['NFS_DATASTORE_NAME']
+    datastore_name = testbed.config['VM_DATASTORE_NAME']
     placement_spec = vm_placement_helper.get_placement_spec_for_resource_pool(
         stub_config,
         datacenter_name,

--- a/samples/vsphere/vcenter/vm/create/create_exhaustive_vm.py
+++ b/samples/vsphere/vcenter/vm/create/create_exhaustive_vm.py
@@ -44,7 +44,6 @@ Sample Prerequisites:
     - vm folder
     - resource pool
     - datastore
-    - cluster
     - standard switch network
     - distributed switch network
     - An iso file on the datastore mentioned above
@@ -74,9 +73,9 @@ def setup(context=None):
 
 def run():
     # Get a placement spec
-    datacenter_name = testbed.config['DATACENTER2_NAME']
+    datacenter_name = testbed.config['VM_DATACENTER_NAME']
     vm_folder_name = testbed.config['VM_FOLDER2_NAME']
-    datastore_name = testbed.config['NFS_DATASTORE_NAME']
+    datastore_name = testbed.config['VM_DATASTORE_NAME']
     std_portgroup_name = testbed.config['STDPORTGROUP_NAME']
     dv_portgroup_name = testbed.config['VDPORTGROUP1_NAME']
     placement_spec = vm_placement_helper.get_placement_spec_for_resource_pool(

--- a/samples/vsphere/vcenter/vm/hardware/disk.py
+++ b/samples/vsphere/vcenter/vm/hardware/disk.py
@@ -95,8 +95,8 @@ def setup(context=None):
 
     # Get the datacenter and datastore managed objects to be able to create and
     # delete VMDKs, which are backings for a VM Disk.
-    datacenter_name = testbed.config['DATACENTER2_NAME']
-    datastore_name = testbed.config['NFS_DATASTORE_NAME']
+    datacenter_name = testbed.config['VM_DATACENTER_NAME']
+    datastore_name = testbed.config['VM_DATASTORE_NAME']
     datastore_mo = get_datastore_mo(stub_config,
                                     service_instance._stub,
                                     datacenter_name,


### PR DESCRIPTION
Update the configuration inputs to reference the “VM” designated values in the testbed.py file

Also removed the unused prerequisites from the comments.

Verified to work against vSphere 6.5 GA and Python 3.6.

Signed-off-by: Kyle Ruddy <kmruddy@gmail.com>