### PR TITLE
dict.itervalues is deprecated in Python3. Fixing sample

### DIFF
--- a/samples/vsphere/backuprestore/backup_job_list.py
+++ b/samples/vsphere/backuprestore/backup_job_list.py
@@ -56,7 +56,7 @@ class BackupJobList(object):
         job_list = details_client.list()
 
         table = []
-        for info in job_list.itervalues():
+        for info in job_list.values():
             row = [info.start_time.strftime("%b %d %Y %H:%M"),
                    info.duration,
                    info.type,


### PR DESCRIPTION
dict.itervalues is deprecated in Python3. Fixing samples to call method dict.values() works for Python 2.7 & 3

Tested change in Python3 & Python 2.7

Start time           Duration  Type    Status     Location
