### PR TITLE
Add HTML docs for NSX Policy and VMC App APIs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -5,4 +5,8 @@ API references for each product can be found in below zip packages:
 Name       | Online Version                           
 -----------| -----------------------------------------
 client.zip | [vSphere Automation Python API Reference](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/3f9d46be-a5f4-452c-8b1c-ae2bb05bc0a6/58d6917d-4da9-45b1-869a-f68550834f8e/vsphere/py-modindex.html)  
+nsx_policy_api.html | VMware NSX Policy API Reference
+nsx_policy_python_sdk.zip | VMware NSX Policy Python API Reference
 vmc.zip    | VMware Cloud on AWS Python API Reference
+vmc_app_api.html | VMware NSX VMC App API Reference
+vmc_app_python_sdk.zip | VMware NSX VMC App Python API Reference

--- a/doc/vmc_app_api.html
+++ b/doc/vmc_app_api.html
@@ -1,0 +1,12502 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!DOCTYPE HTML>
+
+<HTML>
+<HEAD>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+  <TITLE>vmc-app API Guide</TITLE>
+    <STYLE type="text/css">
+      #content {
+        margin: 2ex 5ex 2ex 5ex;
+        width: 100ex;
+        font-family: verdana, aria, helvetica,sans-serif;
+        font-size: 12px;
+      }
+      h1,h2,h3,h4,h5,h6 {
+        padding: 0;
+        border: 0;
+        margin: 0;
+        margin-top: 1ex;
+      }
+      h2 {
+        margin-top: 2ex;
+      }
+      p {
+        padding: 0;
+        border: 0;
+        margin: 0;
+        padding-bottom: 1ex;
+      }
+      table {
+        border-collapse: collapse;
+        border-color: gray;
+        font-size: 12px;
+        margin: 5px 0
+      }
+      td {
+        border: 1px solid #aaaaaa;
+        padding-left: 3px;
+        text-align: left;
+        vertical-align: top;
+      }
+      td.title-cell {
+        width: 30%;
+        background-color: #cccccc;
+      }
+      span.schema_toggle, span.inline_table_toggle {
+        border:1px solid #999999;
+        margin-left:5px;
+        color:#666666;
+        cursor:pointer;
+        padding:0px 2px;
+      }
+      span.expanded_schema {
+        border:1px solid #CCCCCC;
+        margin:4px 0px 0px 75px;
+        display: block;
+      }
+      span.doc_category {
+        margin-top: 20px;
+        margin-bottom: 20px;
+        font-size: 12px;
+        display:block;
+      }
+      span.help_detail {
+        display:block;
+        margin:1ex 2ex 2ex 1ex;
+      }
+      span.example_request {
+        display:block;
+        margin:1ex 2ex 2ex 1ex;
+        font-family: monospace;
+        white-space: pre;
+      }
+      span.example_response {
+        display:block;
+        margin:1ex 2ex 2ex 1ex;
+        font-family: monospace;
+        white-space: pre;
+      }
+      span.rbac_feature {
+        display:block;
+        margin:1ex 2ex 2ex 1ex;
+      }
+      span.required_permissions {
+        display:block;
+        margin:1ex 2ex 2ex 1ex;
+      }
+      ul {
+        margin-top: 5px;
+        margin-bottom: 20px;
+      }
+      ol {
+        counter-reset: section;                /* Creates a new instance of the section counter with each ol element */
+        list-style-type: none;                 /* Nested couter creates outlined list in API table of contents */
+      }
+      ol li::before {
+        counter-increment: section;            /* Increments only this instance of the section counter */
+        content: counters(section,".") " ";    /* Adds the value of all instances of the section counter separated by a ".". */
+      }
+      .subsection_title {
+        text-decoration: underline;
+      }
+      .subsection {
+        margin: 5px 0px 0px 3em;
+        width: 90%;
+        background-color: #e8e8e8;
+      }
+      .subsection_text {
+        padding: 3px;
+        width: 100%;
+        background-color: #f8f8f8;
+      }
+      .inline_table_div {
+        clear: both;
+        padding: 5px 0px;
+        width: 100%;
+        background-color: #ffffff;
+      }
+      .inline_table {
+        margin-bottom: 0px
+      }
+      .error_table {
+        margin: 7px 0 7px 5em;
+        width: 90%;
+      }
+      tr.header {
+        background-color: #cccccc;
+      }
+      .row {
+        clear: both;
+        width: 100%;
+      }
+      .label {
+        padding: 3px;
+        float: left;
+        width: 25%;
+      }
+      .value {
+        padding: 3px;
+        float: right;
+        width: 72%;
+        background-color: #f8f8f8;
+      }
+      .api_object_title {
+        font-weight: bold;
+      }
+      .experimental {
+        padding-left: 5px;
+        font-weight: normal;
+        font-size: 12px;
+        color: red;
+      }
+      .deprecated {
+        padding-left: 5px;
+        font-weight: normal;
+        font-size: 12px;
+        color: red;
+      }
+      .code {
+        font-weight: normal;
+        font-size: 12px;
+        font-family: Lucida-Console, Monaco, monospace;
+      }
+      .code_block {
+        font-weight: normal;
+        font-size: 12px;
+        font-family: Lucida-Console, Monaco, monospace;
+        padding: 5px;
+        padding-left: 15px;
+      }
+    </STYLE>
+
+    <script type="text/javascript">
+      function toggleSchemaExpansion(oToggleSpan) {
+          var oExpandedPre    = oToggleSpan.nextSibling;
+
+          var bHide = oToggleSpan.innerHTML == "+" ? false : true;
+
+          oToggleSpan.innerHTML      = bHide ? "+"    : "-";
+          oExpandedPre.style.display = bHide ? "none" : "";
+      }
+      function toggleInlineTable(oToggleSpan, sRootDivId, sTableId) {
+          var oTableDiv;
+          if (sTableId) {
+              var oRootDiv = document;
+              if (typeof sRootDivId != "undefined" && sRootDivId != "") {
+                  oRootDiv = document.getElementById(sRootDivId);
+              }
+              var aTableDivs = oRootDiv.getElementsByTagName("div");
+              for (var i = 0; i < aTableDivs.length; i++) {
+                  if (aTableDivs[i].id == sTableId) {
+                      oTableDiv = aTableDivs[i];
+                      break;
+                  }
+              }
+          }
+
+          if (oTableDiv) {
+              var bHide = oToggleSpan.innerHTML == "+" ? false : true;
+              oToggleSpan.innerHTML      = bHide ? "+"    : "-";
+              oTableDiv.style.display = bHide ? "none" : "inline-block";
+          }
+      }
+      function toggleAllInlineTablesInner(oLink, bHide) {
+          var aTableDivs = document.getElementsByTagName("div");
+          for (var i = 0; i < aTableDivs.length; i++) {
+              var oTableDiv = aTableDivs[i];
+              if (oTableDiv.className == "inline_table_div") {
+                  oTableDiv.style.display = bHide ? "none" : "inline-block";
+              }
+          }
+
+          var aSpans = document.getElementsByTagName("span");
+          for (var i = 0; i < aSpans.length; i++) {
+              var oSpan = aSpans[i];
+              if (oSpan.className == "inline_table_toggle") {
+                  oSpan.innerHTML = bHide ? "+" : "-";
+              }
+              if (oSpan.className == "expanded_schema") {
+                  toggleSchemaExpansion(oSpan.previousSibling);
+              }
+          }
+          oLink.innerHTML = bHide ? "+" : "-";
+      }
+      function toggleAllInlineTables(oLink) {
+          var bHide = oLink.innerHTML.indexOf("-") > -1;
+          oLink.innerHTML = bHide ? "collapsing..." : "expanding...";
+          setTimeout(toggleAllInlineTablesInner, 0, oLink, bHide);
+      }
+    </script>
+</HEAD>
+
+<BODY>
+<DIV ID="content">
+  <DIV ID="header">
+    <P STYLE="margin-bottom: 0.2in"><FONT COLOR="#800000">
+      Copyright &copy 2017 VMware, Inc.  All rights reserved.
+      <a href="http://pubs.vmware.com/copyright-trademark.html">
+      Copyright and trademark information.</a>
+    </FONT></P>
+  <P STYLE="margin-bottom: 0.2in">EN-002522-00</P>
+  </DIV>
+
+<H1>vmc-app API Guide</H1>
+<P STYLE="font-size:120%; margin-top: 0.1in">NSX 2.2.0</P>
+
+
+
+
+
+<DIV class="toc">
+  <H2>Table of Contents</H2>
+  <ol>
+     <li><a class="toc_ref" href="#Overview">Overview</a></li>
+     <li><a class="toc_ref" href="#Methods">API Methods</a>
+       
+    <ol>
+          
+          <li>
+            <a class="toc_ref" href="#Sections.Vmc">Vmc</a>
+            
+
+          </li>
+    </ol>
+
+     </li>
+     <li><a class="toc_ref" href="#Types">API Types</a></li>
+     <li><a class="toc_ref" href="#Schemas">API Type Schemas</a></li>
+     <li><a class="toc_ref" href="#Errors">API Errors</a></li>
+  </ol>
+</DIV>
+
+
+<br><br>
+<H2><A name="Overview">Overview</A></H2>
+
+  
+      
+<h3>Introduction</h3>
+<p>
+  vmc-app provides a programmatic API to automate
+  management activities.  The API follows a resource-oriented
+  Representational State Transfer (REST) architecture, using JSON
+  object encoding. Clients interact with the API using RESTful web service
+  calls over the HTTPS protocol.
+</p>
+<p>
+  Each API method is identified by a request method and URI.  Method
+  parameters are specified as key-value pairs appended to the URI.  Unless
+  otherwise noted, request and response bodies are encoded using JSON, and
+  must conform to the JSON schema associated with each method.  The content
+  type of each request and reply is "application/json" unless otherwise
+  specified.  Each request that can be made is documented in the API Methods
+  section.  The associated request and response body schemas are documented in
+  the API Schemas section.
+</p>
+<p>
+  Some APIs may be marked as deprecated. This indicates that the functionality
+  provided by the API has been removed or replaced with a different API. The
+  description of the API will indicate what API(s) to call instead.
+</p>
+<p>
+  Some APIs may be marked as experimental. This indicates that the API
+  may be changed or removed without notice in a future vmc-app release.
+</p>
+<p>
+  It is possible for any request to fail.  Errors are reported using standard
+  HTTP response codes.  It should be assumed the following errors could be
+  returned by any API method: <A HREF="#Errors.301">301 Moved Permanently</A>, <A HREF="#Errors.307">307 Temporary Redirect</A>, <A HREF="#Errors.400">400 Bad Request</A>, <A HREF="#Errors.401">401 Unauthorized</A>, <A HREF="#Errors.403">403 Forbidden</A>, <A HREF="#Errors.500">500 Internal Server Error</A>, <A HREF="#Errors.503">503 Service Unavailable</A>.  Where other errors may be
+  returned, the type of error is indicated in the API method description.  All
+  errors are documented in the API Errors section.
+</p>
+<h3>Request Authentication</h3>
+<p>
+Most API calls require authentication.  This API supports
+HTTP Basic authentication and session-based authentication schemes.
+Multiple authentication schemes may not be used concurrently.
+</p>
+
+<h4>HTTP Basic Authentication</h4>
+<p>
+To authenticate a request using HTTP Basic authentication, the caller's
+credentials are passed using the 'Authorization' header.  The header
+content should consist of a base64-encoded string containing the username and
+password separated by a single colon (":") character, as specified in
+RFC 1945 section 11.1.
+</p>
+<p>
+For example, to authenticate a request using the default credentials of
+user <span class="code">admin</span> with password
+<span class="code">admin</span>, include the following header with the
+request:
+</p>
+<div class="code_block">
+Authorization: Basic YWRtaW46YWRtaW4=
+</div>
+<p>
+The following cURL command will authenticate to the manager using basic
+authentication and will issue a GET request for logical ports:
+</p>
+<div class="code_block">
+curl -k -u USERNAME:PASSWORD https://MANAGER/api/v1/logical-ports
+</div>
+<p>
+where:<br>
+<span class="code">USERNAME</span> is the user to authenticate as,<br>
+<span class="code">PASSWORD</span> is the password to provide, and<br>
+<span class="code">MANAGER</span> is the IP address or host name of the NSX manager<br>
+</p>
+<p>
+For example:
+</p>
+<div class="code_block">
+curl -k -u admin:secretPw99 https://192.168.22.32/api/v1/logical-ports
+</div>
+<p>
+Note: the <span class="code">-k</span> argument instructs cURL to skip
+verifying the manager's self-signed X.509 certificate.
+</p>
+
+<h4>Session-Based Authentication</h4>
+<p>
+Session-based authentication is used by calling the
+<span class="code">/api/session/create</span> authentication API to manage
+a session cookie.  The session cookie returned in the result of a successful
+login must be provided in subsequent requests in order to associate those
+requests with the session.
+</p>
+<p>
+Session state is local to the server responding to the API request.
+Idle sessions will automatically time-out, or can be terminated
+immediately using the <span class="code">POST /api/session/destroy</span> API.
+</p>
+
+<p>
+To obtain a session cookie, POST form data to the server using the
+application/x-ww-form-urlencoded media type, with fields "j_username" and
+"j_password" containing the username and password separated by an ampersand.
+Since an ampersand is a UNIX shell metacharacter, you may need to
+surround the argument with single quotes.
+</p>
+<p>
+The following cURL command
+will authenticate to the server, will deposit the session cookie
+in the file "cookies.txt", and will write all HTTP response headers
+to the file headers.txt. One of these headers is the X-XSRF-TOKEN
+header that you will need to provide in subsequent requests.
+</p>
+
+
+<div class="code_block">
+curl -k -c cookies.txt -D headers.txt -X POST     -d 'j_username=USERNAME&j_password=PASSWORD'     https://MANAGER/api/session/create
+</div>
+
+<p>
+For example:
+</p>
+
+<div class="code_block">
+curl -k -c cookies.txt -D headers.txt -X POST     -d 'j_username=admin&j_password=secretPw99'     https://192.168.22.32/api/session/create
+</div>
+
+<p>
+The manager will respond with the roles and permissions granted to the user,
+and cURL will deposit the session cookie into the file "cookies.txt".
+</p>
+
+<p>
+In subsequent cURL requests, use the -b argument to specify the cookie file.
+You also need to pass the X-XSRF-TOKEN header that was saved to the
+headers.txt file, using cURL's -H option:
+</p>
+
+<div class="code_block">
+curl -k -b cookies.txt -H "`grep X-XSRF-TOKEN headers.txt`"     https://192.168.22.32/api/v1/logical-ports
+</div>
+
+<p>
+When the session expires, the manager will respond with a 403 Forbidden
+HTTP response, at which point you must obtain a new session cookie
+and X-XSRF-TOKEN.
+</p>
+
+<p>
+Session cookies can be destroyed by using the /api/session/destroy
+API:
+</p>
+
+<div class="code_block">
+curl -k -b cookies.txt -H "`grep X-XSRF-TOKEN headers.txt`"     -X POST https://MANAGER/api/session/destroy
+</div>
+
+
+<h3>Example Requests and Responses</h3>
+<p>Example requests and responses are provided for most of the API calls below.
+Your actual response might differ from the example in the number of fields
+returned because optional empty fields are not returned when you make an API
+call.</p>
+
+<h3>Restrictions on Certain Fields in a Request</h3>
+<p>When configuring layer 2 switching, the following fields can contain any
+character except semicolon (;), vertical bar (|), equal sign (=), comma (,),
+tilde (~), and the "at" sign (@). They also have a length limitation as
+specified below:
+<ul>
+  <li>Logical switch display name. Maximum length: 80 bytes.</li>
+  <li>Host switch name in TransportZone. Maximum length: 80 bytes.</li>
+  <li>Uplink name in UplinkHostSwitchProfile. Maximum length: 47 bytes.</li>
+</ul>
+
+<h3>OpenAPI Specification of vmc-app API</h3>
+<p>You can get an OpenAPI specification of the vmc-app API with one
+of the following calls:
+<ul>
+  <li>GET https://&lt;nsx-mgr&gt;/api/v1/spec/openapi/nsx_api.yaml</li>
+  <li>GET https://&lt;nsx-mgr&gt;/api/v1/spec/openapi/nsx_api.json</li>
+</ul>
+
+
+
+
+
+
+
+
+<div style="margin-top: 1ex;">
+  <br><br>
+  <h2 style="display: inline"><a name="Methods">API Methods</a></h2>
+  <span style="float:right">
+    Toggle all tables
+    <span class="inline_table_toggle" onclick="toggleAllInlineTables(this)">
+      +
+    </span>
+  </span>
+</div>
+
+  
+
+    
+    <H3><A name="Sections.Vmc">Vmc</A></H3>
+    <div>
+      <div>
+    
+</div>
+      <div>
+          Associated URIs:
+          <ul>
+                <li>
+                  <a href="#Methods.ListAccounts">GET /cloud-service/api/v1/accounts</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListLinkedVpcs">GET /cloud-service/api/v1/linked-vpcs</a>
+                </li>
+                <li>
+                  <a href="#Methods.GetLinkedVpc">GET /cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListConnectedServices">GET /cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;/connected-services</a>
+                </li>
+                <li>
+                  <a href="#Methods.UpdateConnectedService">PUT /cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;/connected-services/&lt;service-name&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListMgmtVms">GET /cloud-service/api/v1/mgmt-vms</a>
+                </li>
+                <li>
+                  <a href="#Methods.GetMgmgtVmInfo">GET /cloud-service/api/v1/mgmt-vms/&lt;vm-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListPublicIps">GET /cloud-service/api/v1/public-ips</a>
+                </li>
+                <li>
+                  <a href="#Methods.DeletePublicIp">DELETE /cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.GetPublicIp">GET /cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.CreatePublicIp">PUT /cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListRoutes">GET /cloud-service/api/v1/routes</a>
+                </li>
+                <li>
+                  <a href="#Methods.GetSddcUserConfig">GET /cloud-service/api/v1/sddc-user-config</a>
+                </li>
+                <li>
+                  <a href="#Methods.ListVifs">GET /cloud-service/api/v1/vifs</a>
+                </li>
+                <li>
+                  <a href="#Methods.DeleteVifById">DELETE /cloud-service/api/v1/vifs/&lt;vif-id&gt;</a>
+                </li>
+                <li>
+                  <a href="#Methods.AttachVif">POST /cloud-service/api/v1/vifs/&lt;vif-id&gt;</a>
+                </li>
+          </ul>
+      </div>
+    </div>
+        <div id="ListAccounts">
+          <h4>
+            <a name="Methods.ListAccounts">Get SDDC account information.</a>
+          </h4>
+          <span class="help_detail">Retrieve the shadow account and linked VPC account information from VMC provider. This API is a live query to VMC provider.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/accounts</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/accounts/</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">VMCAccounts<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListAccounts', 'VMCAccounts.ListAccounts.Response_Body')">+</span></div>
+  </div>
+    <div id="VMCAccounts.ListAccounts.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.VMCAccounts">
+        <span class="api_object_title">VMCAccounts</span>
+      </a> (<a href="#Schema.VMCAccounts">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>linked_vpc_account</td>
+            
+            <td>linked VPC account number</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>shadow_account</td>
+            
+            <td>Shadow VPC account number</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+  shadow_account: "482663666969",
+  linked_vpc_account: "909992878262"
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListLinkedVpcs">
+          <h4>
+            <a name="Methods.ListLinkedVpcs">List linked VPC information.</a>
+          </h4>
+          <span class="help_detail"></span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/linked-vpcs</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/linked-vpcs</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">LinkedVpcsListResult<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListLinkedVpcs', 'LinkedVpcsListResult.ListLinkedVpcs.Response_Body')">+</span></div>
+  </div>
+    <div id="LinkedVpcsListResult.ListLinkedVpcs.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.LinkedVpcsListResult">
+        <span class="api_object_title">LinkedVpcsListResult</span>
+      </a> (<a href="#Schema.LinkedVpcsListResult">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Linked VPCs list</td>
+            
+            <td>array of <a href="#Type.LinkedVpcInfo">LinkedVpcInfo</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "result_count": 1,
+    "results": [
+        {
+           "linked_vpc_id":"vpc-efeda78a",
+           "linked_vpc_addresses":[
+              "172.31.0.0/16"
+           ],
+           "linked_vpc_subnet_addresses":[
+              "172.31.32.0/20"
+           ],
+           "route_table_ids":[
+              "rtb-588ad73d"
+           ],
+           "arn_role":"arn:aws:iam::122674636182:role/vmware-sddc-formation-493513ce-6488-476-RemoteRole-E38OM4XJOCLD",
+           "linked_vpc_nat_ips":[
+              "172.31.32.159"
+           ],
+           "external_id":"vmware-vmc",
+           "linked_account":"122674636182"
+        }
+    ]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="GetLinkedVpc">
+          <h4>
+            <a name="Methods.GetLinkedVpc">Get linked VPC information.</a>
+          </h4>
+          <span class="help_detail"></span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/linked-vpcs/vpc-efeda78a</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">LinkedVpcInfo<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'GetLinkedVpc', 'LinkedVpcInfo.GetLinkedVpc.Response_Body')">+</span></div>
+  </div>
+    <div id="LinkedVpcInfo.GetLinkedVpc.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.LinkedVpcInfo">
+        <span class="api_object_title">LinkedVpcInfo</span>
+      </a> (<a href="#Schema.LinkedVpcInfo">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>arn_role</td>
+            
+            <td>ARN role for linked VPC operations</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>external_id</td>
+            
+            <td>External identifier for ARN role</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_account</td>
+            
+            <td>Linked VPC account number</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_addresses</td>
+            
+            <td>Linked VPC CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_id</td>
+            
+            <td>Linked VPC identifier</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_nat_ips</td>
+            
+            <td>The IPs of linked VPC NAT rule for service access.</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_subnet_addresses</td>
+            
+            <td>Linked VPC ENIs subnet CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>route_table_ids</td>
+            
+            <td>The identifiers of route tables to be dynamically updated with SDDC networks</td>
+            
+            <td>array of string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>service_arn_role</td>
+            
+            <td>service ARN role</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListConnectedServices">
+          <h4>
+            <a name="Methods.ListConnectedServices">List services connected to this linked vpc</a>
+          </h4>
+          <span class="help_detail">List services connected to this linked vpc, for example, S3. The response consist of all available services along with their status.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;/connected-services</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/linked-vpcs/vpc-01/connected-services</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">ConnectedServiceListResult<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListConnectedServices', 'ConnectedServiceListResult.ListConnectedServices.Response_Body')">+</span></div>
+  </div>
+    <div id="ConnectedServiceListResult.ListConnectedServices.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.ConnectedServiceListResult">
+        <span class="api_object_title">ConnectedServiceListResult</span>
+      </a> (<a href="#Schema.ConnectedServiceListResult">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Connected service status list</td>
+            
+            <td>array of <a href="#Type.ConnectedServiceStatus">ConnectedServiceStatus</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+   "results":  [{
+        "name": "s3",
+        "enabled" : true
+   }]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="UpdateConnectedService">
+          <h4>
+            <a name="Methods.UpdateConnectedService">Connect/Disconnect the service to this linked vpc</a>
+          </h4>
+          <span class="help_detail">Connect/Disconnect the service to the given linked vpc. For example, connect S3. The user will know what services are available through the GET call. If the user is trying to connect/disconnect an unknown service, the POST call will throw a 400 Bad Request error.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">PUT</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/linked-vpcs/&lt;linked-vpc-id&gt;/connected-services/&lt;service-name&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value">ConnectedServiceStatus<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'UpdateConnectedService', 'ConnectedServiceStatus.UpdateConnectedService.Request_Body')">+</span></div>
+  </div>
+    <div id="ConnectedServiceStatus.UpdateConnectedService.Request_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.ConnectedServiceStatus">
+        <span class="api_object_title">ConnectedServiceStatus</span>
+      </a> (<a href="#Schema.ConnectedServiceStatus">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>enabled</td>
+            
+            <td>status of service</td>
+            
+            <td>boolean</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>name</td>
+            
+            <td>service name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">PUT https://<nsx-policy-mgr>/cloud-service/api/v1/linked-vpcs/vpc-01/connected-services/s3
+{
+  "name": "s3",
+  "enabled" : true
+}</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">ConnectedServiceStatus<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'UpdateConnectedService', 'ConnectedServiceStatus.UpdateConnectedService.Response_Body')">+</span></div>
+  </div>
+    <div id="ConnectedServiceStatus.UpdateConnectedService.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.ConnectedServiceStatus">
+        <span class="api_object_title">ConnectedServiceStatus</span>
+      </a> (<a href="#Schema.ConnectedServiceStatus">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>enabled</td>
+            
+            <td>status of service</td>
+            
+            <td>boolean</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>name</td>
+            
+            <td>service name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+  "name": "s3",
+  "enabled" : true
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">crud</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListMgmtVms">
+          <h4>
+            <a name="Methods.ListMgmtVms">List Management VM information.</a>
+          </h4>
+          <span class="help_detail"></span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/mgmt-vms</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/mgmt-vms</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">MgmtVmsListResult<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListMgmtVms', 'MgmtVmsListResult.ListMgmtVms.Response_Body')">+</span></div>
+  </div>
+    <div id="MgmtVmsListResult.ListMgmtVms.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.MgmtVmsListResult">
+        <span class="api_object_title">MgmtVmsListResult</span>
+      </a> (<a href="#Schema.MgmtVmsListResult">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Management VMs list</td>
+            
+            <td>array of <a href="#Type.MgmtVmInfo">MgmtVmInfo</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "result_count": 2,
+    "results": [
+        {
+            "dispaly_name": "vm101",
+            "ip": "10.0.224.10",
+            "id": "vm101",
+            "ports": [
+                443
+            ],
+            "protocols": [
+                "ICMP"
+            ]
+        },
+        {
+            "dispaly_name": "vm104",
+            "ip": "10.0.224.10",
+            "id": "vm104",
+            "ports": [
+                443
+            ],
+            "protocols": [
+                "ICMP"
+            ]
+        }
+    ]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="GetMgmgtVmInfo">
+          <h4>
+            <a name="Methods.GetMgmgtVmInfo">Get management VM access information.</a>
+          </h4>
+          <span class="help_detail">Get management VM access information.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/mgmt-vms/&lt;vm-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/mgmt-vms/<VM name></span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">MgmtVmInfo<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'GetMgmgtVmInfo', 'MgmtVmInfo.GetMgmgtVmInfo.Response_Body')">+</span></div>
+  </div>
+    <div id="MgmtVmInfo.GetMgmgtVmInfo.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.MgmtVmInfo">
+        <span class="api_object_title">MgmtVmInfo</span>
+      </a> (<a href="#Schema.MgmtVmInfo">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Management VM name</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>group_path</td>
+            
+            <td>Group path in policy manager<br><br>For each management VM, a dedicated policy group will be created.
+<br>
+This property will reflect its group path.
+<br>
+</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Management VM identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip_attachment_pairs</td>
+            
+            <td>IP address and attachment id pairs for tagging managment VM</td>
+            
+            <td>array of <a href="#Type.IpAttachmentPair">IpAttachmentPair</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>ips</td>
+            
+            <td>Local IPs of a management VM</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>services</td>
+            
+            <td>Services which will be provided in this management VM<br><br>Details about protocols and ports which services will be provided.
+<br>
+</td>
+            
+            <td>array of <a href="#Type.MgmtServiceEntry">MgmtServiceEntry</a></td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "display_name":"VC",
+    "ips": ["10.0.224.10/32", "10.0.1.2/24"],
+    "protocols": ["ICMP"],
+    "ports":  ["443"]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.404">404 Not Found</a></li>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListPublicIps">
+          <h4>
+            <a name="Methods.ListPublicIps">List all Public IPs</a>
+          </h4>
+          <span class="help_detail">List all public IPs obtained in the SDDC.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/public-ips</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/public-ips/</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">PublicIpsListResult<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListPublicIps', 'PublicIpsListResult.ListPublicIps.Response_Body')">+</span></div>
+  </div>
+    <div id="PublicIpsListResult.ListPublicIps.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.PublicIpsListResult">
+        <span class="api_object_title">PublicIpsListResult</span>
+      </a> (<a href="#Schema.PublicIpsListResult">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Public IP list</td>
+            
+            <td>array of <a href="#Type.PublicIp">PublicIp</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "result_count": 2,
+    "results": [
+        {
+            "ip": "34.212.160.142",
+            "id": "nsx-public-ip",
+            "display_name": "nsx-public-ip"
+        },
+        {
+            "ip": "34.218.111.236",
+            "id": "nsx-public-ip-2",
+            "display_name": "nsx-public-ip-2"
+        }
+    ]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="DeletePublicIp">
+          <h4>
+            <a name="Methods.DeletePublicIp">Delete a public IP</a>
+          </h4>
+          <span class="help_detail">Delete a public IP. The IP will be released in VMC provider.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">DELETE</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value">DeleteRequestParameters<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'DeletePublicIp', 'DeleteRequestParameters.DeletePublicIp.Query_Parameters')">+</span></div>
+  </div>
+    <div id="DeleteRequestParameters.DeletePublicIp.Query_Parameters" style="display:none" class="inline_table_div">
+      <a href="#Type.DeleteRequestParameters">
+        <span class="api_object_title">DeleteRequestParameters</span>
+      </a> (<a href="#Schema.DeleteRequestParameters">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>force</td>
+            
+            <td>Force delete the resource even if it is being used somewhere
+<br><br>If true, deleting the resource succeeds even if it is being
+<br>
+referred as a resource reference.
+<br>
+</td>
+            
+            <td>boolean</td>
+            
+            <td>Default: "False"</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">DELETE https://<nsx-policy-mgr>/cloud-service/api/v1/public-ips/nsx-public-ip
+DELETE https://<nsx-policy-mgr>/cloud-service/api/v1/public-ips/nsx-public-ip?force=true</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  <div class="value"><i>n/a</i></div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">crud</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="GetPublicIp">
+          <h4>
+            <a name="Methods.GetPublicIp">Get the public IP information.</a>
+          </h4>
+          <span class="help_detail">Get the public IP information.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/public-ips/nsx-public-ip</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">PublicIp<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'GetPublicIp', 'PublicIp.GetPublicIp.Response_Body')">+</span></div>
+  </div>
+    <div id="PublicIp.GetPublicIp.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.PublicIp">
+        <span class="api_object_title">PublicIp</span>
+      </a> (<a href="#Schema.PublicIp">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td></td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Public IP identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip</td>
+            
+            <td></td>
+            
+            <td><a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "ip": "34.212.160.142",
+    "id": "nsx-public-ip",
+    "display_name": "nsx-public-ip"
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.404">404 Not Found</a></li>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="CreatePublicIp">
+          <h4>
+            <a name="Methods.CreatePublicIp">Create or update a public IP.</a>
+          </h4>
+          <span class="help_detail">This API is used to create or update a public IP. In creating, the API allocates a new public IP from VMC provider. In updating, only the display name can be modified, the IP is read-only.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">PUT</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/public-ips/&lt;public-ip-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value">PublicIp<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'CreatePublicIp', 'PublicIp.CreatePublicIp.Request_Body')">+</span></div>
+  </div>
+    <div id="PublicIp.CreatePublicIp.Request_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.PublicIp">
+        <span class="api_object_title">PublicIp</span>
+      </a> (<a href="#Schema.PublicIp">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td></td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Public IP identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip</td>
+            
+            <td></td>
+            
+            <td><a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">PUT https://<nsx-policy-mgr>/cloud-service/v1/public-ips/nsx-public-ip
+{
+	"id": "nsx-public-ip",
+	"display_name":"nsx-public-ip"
+}</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">PublicIp<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'CreatePublicIp', 'PublicIp.CreatePublicIp.Response_Body')">+</span></div>
+  </div>
+    <div id="PublicIp.CreatePublicIp.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.PublicIp">
+        <span class="api_object_title">PublicIp</span>
+      </a> (<a href="#Schema.PublicIp">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td></td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Public IP identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip</td>
+            
+            <td></td>
+            
+            <td><a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+    "ip": "34.212.160.142",
+    "id": "nsx-public-ip",
+    "display_name": "nsx-public-ip"
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">crud</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.404">404 Not Found</a></li>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListRoutes">
+          <h4>
+            <a name="Methods.ListRoutes">Get BGP routes from Direct Connect.</a>
+          </h4>
+          <span class="help_detail">Retrieve BGP routes that are populated by Direct Connect from VMC provider. This API is a live query to VMC provider.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/routes</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/routes</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">BGPRoutes<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListRoutes', 'BGPRoutes.ListRoutes.Response_Body')">+</span></div>
+  </div>
+    <div id="BGPRoutes.ListRoutes.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.BGPRoutes">
+        <span class="api_object_title">BGPRoutes</span>
+      </a> (<a href="#Schema.BGPRoutes">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>bgp_routes</td>
+            
+            <td>BGP routes</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+  bgp_routes: ["0.0.0.0/0"]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="GetSddcUserConfig">
+          <h4>
+            <a name="Methods.GetSddcUserConfig">Get the user-level SDDC configuration parameters</a>
+          </h4>
+          <span class="help_detail">Get the user-level SDDC configuration parameters</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/sddc-user-config</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/sddc-user-config</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">SddcUserConfiguration<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'GetSddcUserConfig', 'SddcUserConfiguration.GetSddcUserConfig.Response_Body')">+</span></div>
+  </div>
+    <div id="SddcUserConfiguration.GetSddcUserConfig.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.SddcUserConfiguration">
+        <span class="api_object_title">SddcUserConfiguration</span>
+      </a> (<a href="#Schema.SddcUserConfiguration">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>compute_gateway</td>
+            
+            <td>Compute gateway name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>dx_interface_label</td>
+            
+            <td>DirectConnect interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_interface_label</td>
+            
+            <td>Linked VPC interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>management_gateway</td>
+            
+            <td>Management gateway name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>mgmt_addresses</td>
+            
+            <td>Management VMs CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>provider_name</td>
+            
+            <td>Provider Name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>public_interface_label</td>
+            
+            <td>Public interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>sddc_infra_addresses</td>
+            
+            <td>SDDC Infra CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>vpn_dx_ips</td>
+            
+            <td>Local IPs for VPN tunnel over Direct Connect</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>vpn_internet_ips</td>
+            
+            <td>Public IPs for VPN tunnel over internet</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+  "sddc_infra_addresses": ["10.0.0.1/24"],
+  "mgmt_addresses": ["10.0.0.2/24"],
+  "vpn_internet_ip": "10.161.10.53",
+  "compute_gateway": "cgw",
+  "linked_vpc_interface_label": "cgw-cross-vpc",
+  "management_gateway": "mgw",
+  "provider_name": "vmc",
+  "public_interface_label": "cgw-public",
+  "dx_interface_label": "cgw-direct-connect"
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="ListVifs">
+          <h4>
+            <a name="Methods.ListVifs">List all Direct Connect VIFs (Virtual Interface) available in the SDDC</a>
+          </h4>
+          <span class="help_detail">Return all non-connected VIFs (with states "avalible", "down", "pending" and "confirming") and connected VIFs that are available to the SDDC.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">GET</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/vifs</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">GET https://<nsx-policy-mgr>/cloud-service/api/v1/vifs/</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  
+                  <div class="value">Content-type: application/json</div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value">VifsListResult<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'ListVifs', 'VifsListResult.ListVifs.Response_Body')">+</span></div>
+  </div>
+    <div id="VifsListResult.ListVifs.Response_Body" style="display:none" class="inline_table_div">
+      <a href="#Type.VifsListResult">
+        <span class="api_object_title">VifsListResult</span>
+      </a> (<a href="#Schema.VifsListResult">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>VIFs list</td>
+            
+            <td>array of <a href="#Type.VirtualInterface">VirtualInterface</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+            <span class="subsection_title">Example Response:</span>
+            <span class="example_response">{
+  "results":  [{
+       "id": "dxvif-fglqwzf5",
+       "name": "vmc-sddc-1",
+       "state": "CONNECTED",
+       "direct_connect_id" : "dxcon-17e8147e",
+       "bgp_status" : "DOWN"
+  }]
+}</span>
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">read</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="DeleteVifById">
+          <h4>
+            <a name="Methods.DeleteVifById">Delete a Direct Connect VIF (Virtual Interface).</a>
+          </h4>
+          <span class="help_detail">Detach and delete a Direct Connect VIF (Virtual Interface) from the SDDC. Detach and delete are one operation in VMC provider, a Direct Connect VIF will be deleted after detached.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">DELETE</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/vifs/&lt;vif-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">DELETE https://<nsx-policy-mgr>/cloud-service/api/v1/vifs/dxvif-fglqwzf5</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  <div class="value"><i>n/a</i></div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">crud</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+        <div id="AttachVif">
+          <h4>
+            <a name="Methods.AttachVif">Attach a Direct Connect VIF (Virtual Interface) to the SDDC.</a>
+          </h4>
+          <span class="help_detail">Perform the attach operation in VMC provider to attach the specified VIF (Virtual Interface) to the SDDC.</span>
+          <span class="subsection_title">Request:</span>
+          <div class="subsection">
+            <div class="row">
+              <div class="label">Method:</div>
+              <div class="value">POST</div>
+            </div>
+            <div class="row">
+              <div class="label">URI Path:</div>
+              <div class="value">/cloud-service/api/v1/vifs/&lt;vif-id&gt;</div>
+            </div>
+            <div class="row">
+              <div class="label">Request Headers:</div>
+                <div class="value"><i>n/a</i></div>
+            </div>
+            
+            
+  
+  <div class="row">
+    <div class="label">Query Parameters:</div>
+    <div class="value">VifAction<span class="inline_table_toggle" onclick="toggleInlineTable(this, 'AttachVif', 'VifAction.AttachVif.Query_Parameters')">+</span></div>
+  </div>
+    <div id="VifAction.AttachVif.Query_Parameters" style="display:none" class="inline_table_div">
+      <a href="#Type.VifAction">
+        <span class="api_object_title">VifAction</span>
+      </a> (<a href="#Schema.VifAction">schema</a>)
+      
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>action</td>
+            
+            <td>Direct Connect VIF (Virtual Interface) action</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Enum: ATTACH</td>
+          </tr>
+      </tbody>
+    </table>
+
+    </div>
+
+              
+  
+  <div class="row">
+    <div class="label">Request Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+            <div style="clear:both"></div>
+          </div>
+          <br>
+
+            <span class="subsection_title">Example Request:</span>
+            <span class="example_request">POST https://<nsx-policy-mgr>/cloud-service/api/v1/vifs/dxvif-fglqwzf5?action=ATTACH</span>
+
+          <span class="subsection_title">Successful Response:</span>
+          
+            <div class="subsection">
+              <div class="row">
+                <div class="label">Response Code:</div>
+                <div class="value">200 OK</div>
+              </div>
+              <div class="row">
+                <div class="label">Response Headers:</div>
+                  <div class="value"><i>n/a</i></div>
+                </div>
+                
+                  
+  
+  <div class="row">
+    <div class="label">Response Body:</div>
+    <div class="value"><i>n/a</i></div>
+  </div>
+
+              <div style="clear:both"></div>
+            </div>
+            <br>
+
+
+            <span class="subsection_title">Required Permissions:</span>
+            <span class="required_permissions">crud</span>
+
+            <span class="subsection_title">Feature:</span>
+            <span class="rbac_feature">vmc_user_features</span>
+
+            <span class="subsection_title">Additional Errors:</span>
+            <ul>
+                <li><a href="#Errors.301">301 Moved Permanently</a></li>
+                <li><a href="#Errors.307">307 Temporary Redirect</a></li>
+                <li><a href="#Errors.400">400 Bad Request</a></li>
+                <li><a href="#Errors.403">403 Forbidden</a></li>
+                <li><a href="#Errors.500">500 Internal Server Error</a></li>
+                <li><a href="#Errors.503">503 Service Unavailable</a></li>
+            </ul>
+        </div>
+    <br>
+
+
+
+
+
+<br>
+<H2><A name="Types">API Types</A></H2><br>
+
+  
+
+    <h4>
+      <a name="Type.ApiError">ApiError</a> (<a href="#Schema.ApiError">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Detailed information about an API error</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>details</td>
+            
+            <td>Further details about the error</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>error_code</td>
+            
+            <td>A numeric error code</td>
+            
+            <td>integer</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>error_data</td>
+            
+            <td>Additional data about the error</td>
+            
+            <td>object</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>error_message</td>
+            
+            <td>A description of the error</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>module_name</td>
+            
+            <td>The module name where the error occurred</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>related_errors</td>
+            
+            <td>Other errors related to this error</td>
+            
+            <td>array of <a href="#Type.ApiError">ApiError</a></td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.BGPRoutes">BGPRoutes</a> (<a href="#Schema.BGPRoutes">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">BGP routes</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>bgp_routes</td>
+            
+            <td>BGP routes</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.ConnectedServiceListResult">ConnectedServiceListResult</a> (<a href="#Schema.ConnectedServiceListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">List result for connected service(s) related to a linked vpc</span>
+    <p>
+    <span class="help_detail">A list of status of 'Enabled/Disabled' for a service connected to a linked vpc</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Connected service status list</td>
+            
+            <td>array of <a href="#Type.ConnectedServiceStatus">ConnectedServiceStatus</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.ConnectedServiceStatus">ConnectedServiceStatus</a> (<a href="#Schema.ConnectedServiceStatus">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Connected service status</span>
+    <p>
+    <span class="help_detail">Status of 'Enabled/Disabled' for a service connected to a linked vpc</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>enabled</td>
+            
+            <td>status of service</td>
+            
+            <td>boolean</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>name</td>
+            
+            <td>service name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.DeleteRequestParameters">DeleteRequestParameters</a> (<a href="#Schema.DeleteRequestParameters">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Parameters that affect how delete operations are processed</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>force</td>
+            
+            <td>Force delete the resource even if it is being used somewhere
+<br><br>If true, deleting the resource succeeds even if it is being
+<br>
+referred as a resource reference.
+<br>
+</td>
+            
+            <td>boolean</td>
+            
+            <td>Default: "False"</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.DiscoveredResource">DiscoveredResource</a> (<a href="#Schema.DiscoveredResource">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Base class for resources that are discovered and automatically updated</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_last_sync_time</td>
+            
+            <td>Timestamp of last modification</td>
+            
+            <td><a href="#Type.EpochMsTimestamp">EpochMsTimestamp</a></td>
+            
+            <td>Readonly<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>description</td>
+            
+            <td>Description of this resource</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 1024<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Identifier to use when displaying entity in logs or GUI<br><br>Defaults to ID if not set</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 255<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>resource_type</td>
+            
+            <td>The type of this resource.</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>tags</td>
+            
+            <td>Opaque identifiers meaningful to the API user</td>
+            
+            <td>array of <a href="#Type.Tag">Tag</a></td>
+            
+            <td>Maximum items: 30</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.EmbeddedResource">EmbeddedResource</a> (<a href="#Schema.EmbeddedResource">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Base class for resources that are embedded in other resources</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_owner</td>
+            
+            <td>Owner of this resource</td>
+            
+            <td><a href="#Type.OwnerResourceLink">OwnerResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_revision</td>
+            
+            <td>Generation of this resource config<br><br>The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.</td>
+            
+            <td>int</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>description</td>
+            
+            <td>Description of this resource</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 1024<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Identifier to use when displaying entity in logs or GUI<br><br>Defaults to ID if not set</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 255<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Identifier of the resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>resource_type</td>
+            
+            <td>The type of this resource.</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.EpochMsTimestamp">EpochMsTimestamp</a> (<a href="#Schema.EpochMsTimestamp">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Timestamp in milliseconds since epoch</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>EpochMsTimestamp</td>
+            
+            <td>Timestamp in milliseconds since epoch</td>
+            
+            <td>integer</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.IPv4Address">IPv4Address</a> (<a href="#Schema.IPv4Address">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">IPv4 address</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>IPv4Address</td>
+            
+            <td>IPv4 address</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.IPv4CIDRBlock">IPv4CIDRBlock</a> (<a href="#Schema.IPv4CIDRBlock">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">IPv4 CIDR Block</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>IPv4CIDRBlock</td>
+            
+            <td>IPv4 CIDR Block</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.InterfaceStatistics">InterfaceStatistics</a> (<a href="#Schema.InterfaceStatistics">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Statistics for a network interface</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>rx_bytes</td>
+            
+            <td>Count of bytes received on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>rx_errors</td>
+            
+            <td>Count of receive errors occurring on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>rx_packets</td>
+            
+            <td>Count of packets received on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>tx_bytes</td>
+            
+            <td>Count of bytes transmitted on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>tx_errors</td>
+            
+            <td>Count of transmit errors occurring on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>tx_packets</td>
+            
+            <td>Count of packets transmitted on this port</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.IpAttachmentPair">IpAttachmentPair</a> (<a href="#Schema.IpAttachmentPair">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title"></span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>attachment_id</td>
+            
+            <td>Attachment id which maps to management VM IP</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>ip</td>
+            
+            <td>Management VM IP Address</td>
+            
+            <td><a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.LinkedVpcInfo">LinkedVpcInfo</a> (<a href="#Schema.LinkedVpcInfo">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Linked VPC info</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>arn_role</td>
+            
+            <td>ARN role for linked VPC operations</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>external_id</td>
+            
+            <td>External identifier for ARN role</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_account</td>
+            
+            <td>Linked VPC account number</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_addresses</td>
+            
+            <td>Linked VPC CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_id</td>
+            
+            <td>Linked VPC identifier</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_nat_ips</td>
+            
+            <td>The IPs of linked VPC NAT rule for service access.</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_subnet_addresses</td>
+            
+            <td>Linked VPC ENIs subnet CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>route_table_ids</td>
+            
+            <td>The identifiers of route tables to be dynamically updated with SDDC networks</td>
+            
+            <td>array of string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>service_arn_role</td>
+            
+            <td>service ARN role</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.LinkedVpcsListResult">LinkedVpcsListResult</a> (<a href="#Schema.LinkedVpcsListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Linked VPC list query result</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Linked VPCs list</td>
+            
+            <td>array of <a href="#Type.LinkedVpcInfo">LinkedVpcInfo</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.ListResult">ListResult</a> (<a href="#Schema.ListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Base class for list results from collections</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.ManagedResource">ManagedResource</a> (<a href="#Schema.ManagedResource">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Base type for resources that are managed by API clients</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_create_time</td>
+            
+            <td>Timestamp of resource creation</td>
+            
+            <td><a href="#Type.EpochMsTimestamp">EpochMsTimestamp</a></td>
+            
+            <td>Readonly<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>_create_user</td>
+            
+            <td>ID of the user who created this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_last_modified_time</td>
+            
+            <td>Timestamp of last modification</td>
+            
+            <td><a href="#Type.EpochMsTimestamp">EpochMsTimestamp</a></td>
+            
+            <td>Readonly<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>_last_modified_user</td>
+            
+            <td>ID of the user who last modified this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_protection</td>
+            
+            <td>Indicates protection status of this resource<br><br>Protection status is one of the following:
+<br>
+PROTECTED - the client who retrieved the entity is not allowed
+<br>
+            to modify it.
+<br>
+NOT_PROTECTED - the client who retrieved the entity is allowed
+<br>
+                to modify it
+<br>
+REQUIRE_OVERRIDE - the client who retrieved the entity is a super
+<br>
+                   user and can modify it, but only when providing
+<br>
+                   the request header X-Allow-Overwrite=true.
+<br>
+UNKNOWN - the _protection field could not be determined for this
+<br>
+          entity.
+<br>
+</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_revision</td>
+            
+            <td>Generation of this resource config<br><br>The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.</td>
+            
+            <td>int</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_system_owned</td>
+            
+            <td>Indicates system owned resource</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>description</td>
+            
+            <td>Description of this resource</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 1024<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Identifier to use when displaying entity in logs or GUI<br><br>Defaults to ID if not set</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 255<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Unique identifier of this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly<br>Sortable</td>
+          </tr>
+          <tr>
+            <td>resource_type</td>
+            
+            <td>The type of this resource.</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>tags</td>
+            
+            <td>Opaque identifiers meaningful to the API user</td>
+            
+            <td>array of <a href="#Type.Tag">Tag</a></td>
+            
+            <td>Maximum items: 30</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.MgmtServiceEntry">MgmtServiceEntry</a> (<a href="#Schema.MgmtServiceEntry">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Management VM service entry</span>
+    <p>
+    <span class="help_detail">Service entry describes the detail of a network service. Either a existing
+<br>
+service path or TCP/UDP/ICMP protocol/ports details could be specified.
+<br>
+</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Display name for this service</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>name</td>
+            
+            <td>Name of service entry<br><br>Service entry name which was based on protocol 'TCP'. The good
+<br>
+example is 'HTTP', 'HTTPS' etc. If no specification, a default
+<br>
+name will be generated in format protocol_port, ex. 'TCP_8080'.
+<br>
+</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>path</td>
+            
+            <td>Service path in policy manager</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>ports</td>
+            
+            <td>Ports to provide this service<br><br>Service ports is required if resource_type is 'TCPEntry' or 'UDPEntry'.
+<br>
+</td>
+            
+            <td>array of int</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>resource_type</td>
+            
+            <td></td>
+            
+            <td>string</td>
+            
+            <td>Enum: ICMPEntry, TCPEntry, UDPEntry</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.MgmtVmInfo">MgmtVmInfo</a> (<a href="#Schema.MgmtVmInfo">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Management VM access information</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Management VM name</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>group_path</td>
+            
+            <td>Group path in policy manager<br><br>For each management VM, a dedicated policy group will be created.
+<br>
+This property will reflect its group path.
+<br>
+</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Management VM identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip_attachment_pairs</td>
+            
+            <td>IP address and attachment id pairs for tagging managment VM</td>
+            
+            <td>array of <a href="#Type.IpAttachmentPair">IpAttachmentPair</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>ips</td>
+            
+            <td>Local IPs of a management VM</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>services</td>
+            
+            <td>Services which will be provided in this management VM<br><br>Details about protocols and ports which services will be provided.
+<br>
+</td>
+            
+            <td>array of <a href="#Type.MgmtServiceEntry">MgmtServiceEntry</a></td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.MgmtVmsListResult">MgmtVmsListResult</a> (<a href="#Schema.MgmtVmsListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Management VM list query result</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Management VMs list</td>
+            
+            <td>array of <a href="#Type.MgmtVmInfo">MgmtVmInfo</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.NoRestRequestParameters">NoRestRequestParameters</a> (<a href="#Schema.NoRestRequestParameters">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title"></span>
+    <p>
+    <span class="help_detail">Parameter definition for requests that do not allow parameters.</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>NoRestRequestParameters</td>
+            
+            <td>Parameter definition for requests that do not allow parameters.</td>
+            
+            <td>object</td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.OwnerResourceLink">OwnerResourceLink</a> (<a href="#Schema.OwnerResourceLink">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Link to this resource</span>
+    <p>
+    <span class="help_detail">The server will populate this field when returing the resource. Ignored on PUT and POST.</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>action</td>
+            
+            <td>Optional action</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>href</td>
+            
+            <td>Link to resource</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>rel</td>
+            
+            <td>Link relation type<br><br>Custom relation type (follows RFC 5988 where appropriate definitions exist)</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.PrefixInfo">PrefixInfo</a> (<a href="#Schema.PrefixInfo">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Service IP prefixes information</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td>Display name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>prefixes</td>
+            
+            <td>Service IP prefixes</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.PrefixesListResult">PrefixesListResult</a> (<a href="#Schema.PrefixesListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Service Prefix list query result</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Service Prefixes list</td>
+            
+            <td>array of <a href="#Type.PrefixInfo">PrefixInfo</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.PublicIp">PublicIp</a> (<a href="#Schema.PublicIp">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title"></span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>display_name</td>
+            
+            <td></td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Public IP identifier</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>ip</td>
+            
+            <td></td>
+            
+            <td><a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.PublicIpsListResult">PublicIpsListResult</a> (<a href="#Schema.PublicIpsListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Public IP list</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>Public IP list</td>
+            
+            <td>array of <a href="#Type.PublicIp">PublicIp</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.Resource">Resource</a> (<a href="#Schema.Resource">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Base class for resources</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.ResourceLink">ResourceLink</a> (<a href="#Schema.ResourceLink">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">A link to a related resource</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>action</td>
+            
+            <td>Optional action</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>href</td>
+            
+            <td>Link to resource</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>rel</td>
+            
+            <td>Link relation type<br><br>Custom relation type (follows RFC 5988 where appropriate definitions exist)</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.RevisionedResource">RevisionedResource</a> (<a href="#Schema.RevisionedResource">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">A base class for types that track revisions</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_revision</td>
+            
+            <td>Generation of this resource config<br><br>The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.</td>
+            
+            <td>int</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.SddcUserConfiguration">SddcUserConfiguration</a> (<a href="#Schema.SddcUserConfiguration">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">SDDC configuration parameters for users</span>
+    <p>
+    <span class="help_detail">SDDC configuration parameters for users. User-level addresses/CIDRs are provided.</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>compute_gateway</td>
+            
+            <td>Compute gateway name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>dx_interface_label</td>
+            
+            <td>DirectConnect interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>linked_vpc_interface_label</td>
+            
+            <td>Linked VPC interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>management_gateway</td>
+            
+            <td>Management gateway name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>mgmt_addresses</td>
+            
+            <td>Management VMs CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>provider_name</td>
+            
+            <td>Provider Name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>public_interface_label</td>
+            
+            <td>Public interface label name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>sddc_infra_addresses</td>
+            
+            <td>SDDC Infra CIDRs</td>
+            
+            <td>array of <a href="#Type.IPv4CIDRBlock">IPv4CIDRBlock</a></td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>vpn_dx_ips</td>
+            
+            <td>Local IPs for VPN tunnel over Direct Connect</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>vpn_internet_ips</td>
+            
+            <td>Public IPs for VPN tunnel over internet</td>
+            
+            <td>array of <a href="#Type.IPv4Address">IPv4Address</a></td>
+            
+            <td></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.SelfResourceLink">SelfResourceLink</a> (<a href="#Schema.SelfResourceLink">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Link to this resource</span>
+    <p>
+    <span class="help_detail">The server will populate this field when returing the resource. Ignored on PUT and POST.</span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>action</td>
+            
+            <td>Optional action</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>href</td>
+            
+            <td>Link to resource</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+          <tr>
+            <td>rel</td>
+            
+            <td>Link relation type<br><br>Custom relation type (follows RFC 5988 where appropriate definitions exist)</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.Tag">Tag</a> (<a href="#Schema.Tag">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Arbitrary key-value pairs that may be attached to an entity</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>scope</td>
+            
+            <td>Tag scope<br><br>Tag searches may optionally be restricted by scope</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 30<br>Default: ""</td>
+          </tr>
+          <tr>
+            <td>tag</td>
+            
+            <td>Tag value<br><br>Identifier meaningful to user</td>
+            
+            <td>string</td>
+            
+            <td>Maximum length: 65<br>Default: ""</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.TaskProperties">TaskProperties</a> (<a href="#Schema.TaskProperties">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Task properties</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>async_response_available</td>
+            
+            <td>True if response for asynchronous request is available</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cancelable</td>
+            
+            <td>True if this task can be canceled</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>description</td>
+            
+            <td>Description of the task</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>end_time</td>
+            
+            <td>The end time of the task in epoch milliseconds</td>
+            
+            <td><a href="#Type.EpochMsTimestamp">EpochMsTimestamp</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>Identifier for this task</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>message</td>
+            
+            <td>A message describing the disposition of the task</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>progress</td>
+            
+            <td>Task progress if known, from 0 to 100</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly<br>Minimum: 0<br>Maximum: 100</td>
+          </tr>
+          <tr>
+            <td>request_method</td>
+            
+            <td>HTTP request method</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>request_uri</td>
+            
+            <td>URI of the method invocation that spawned this task</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>start_time</td>
+            
+            <td>The start time of the task in epoch milliseconds</td>
+            
+            <td><a href="#Type.EpochMsTimestamp">EpochMsTimestamp</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>status</td>
+            
+            <td>Current status of the task</td>
+            
+            <td><a href="#Type.TaskStatus">TaskStatus</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>user</td>
+            
+            <td>Name of the user who created this task</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.TaskStatus">TaskStatus</a> (<a href="#Schema.TaskStatus">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Current status of the task</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>TaskStatus</td>
+            
+            <td>Current status of the task</td>
+            
+            <td>string</td>
+            
+            <td>Enum: running, error, success, canceling, canceled, killed</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.VMCAccounts">VMCAccounts</a> (<a href="#Schema.VMCAccounts">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Shadow account and linked VPC account</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>linked_vpc_account</td>
+            
+            <td>linked VPC account number</td>
+            
+            <td>string</td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>shadow_account</td>
+            
+            <td>Shadow VPC account number</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.VifAction">VifAction</a> (<a href="#Schema.VifAction">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title"></span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>action</td>
+            
+            <td>Direct Connect VIF (Virtual Interface) action</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Enum: ATTACH</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.VifsListResult">VifsListResult</a> (<a href="#Schema.VifsListResult">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title">Direct Connect VIFs (Virtual Interface) list query result</span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>_links</td>
+            
+            <td>References related to this resource<br><br>The server will populate this field when returing the resource. Ignored on PUT and POST.</td>
+            
+            <td>array of <a href="#Type.ResourceLink">ResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_schema</td>
+            
+            <td>Schema for this resource</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>_self</td>
+            
+            <td>Link to this resource</td>
+            
+            <td><a href="#Type.SelfResourceLink">SelfResourceLink</a></td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>cursor</td>
+            
+            <td>Opaque cursor to be used for getting next page of records (supplied by current result page)</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>result_count</td>
+            
+            <td>Count of results found (across all pages), set only on first page</td>
+            
+            <td>integer</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>results</td>
+            
+            <td>VIFs list</td>
+            
+            <td>array of <a href="#Type.VirtualInterface">VirtualInterface</a></td>
+            
+            <td></td>
+          </tr>
+          <tr>
+            <td>sort_ascending</td>
+            
+            <td>If true, results are sorted in ascending order</td>
+            
+            <td>boolean</td>
+            
+            <td>Readonly</td>
+          </tr>
+          <tr>
+            <td>sort_by</td>
+            
+            <td>Field by which records are sorted</td>
+            
+            <td>string</td>
+            
+            <td>Readonly</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <h4>
+      <a name="Type.VirtualInterface">VirtualInterface</a> (<a href="#Schema.VirtualInterface">schema</a>)
+    </h4>
+    <p>
+    <span class="api_object_title"></span>
+    <p>
+    <span class="help_detail"></span>
+    
+    
+    
+    
+    <table border="1">
+      <tbody>
+        <tr class="header">
+          <td>Name</td>
+          <td width="60%">Description</td>
+          <td>Type</td>
+          <td>Notes</td>
+        </tr>
+          <tr>
+            <td>bgp_status</td>
+            
+            <td>BGP status</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Enum: UP, DOWN</td>
+          </tr>
+          <tr>
+            <td>direct_connect_id</td>
+            
+            <td>Identifier for the Direct Connect</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>id</td>
+            
+            <td>VIF (Virtual Interface) identifier<br><br>Identifier for the virtual interface</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>name</td>
+            
+            <td>VIF name</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span></td>
+          </tr>
+          <tr>
+            <td>state</td>
+            
+            <td>VIF State</td>
+            
+            <td>string</td>
+            
+            <td><span style="color: rgb(153, 0, 0);">Required</span><br>Enum: CONFIRMING, VERIFYING, PENDING, AVAILABLE, DOWN, DELETING, DELETED, REJECTED, ATTACHED, ATTACHING, ERROR</td>
+          </tr>
+      </tbody>
+    </table>
+
+    <br>
+
+
+
+<br><br>
+<H2><A name="Schemas">API Type Schemas</A></H2>
+
+  
+      <p>Request and response bodies for API Methods are specified
+using the proposed JSON Schema format (revision 03) documented
+at <a href="http://json-schema.org/">http://json-schema.org/
+</a>.  All data returned by API methods references the
+schema being used through the an attribute of the
+top-level object named "_schema".  These will refer to the
+schema definitions provided as described in the Embedded
+API Documentation methods of the API.  The schemas make use
+of JSON referencing to reduce restatement of the same
+schema information in multiple places.</p>
+
+<H4>JsonSchema</H4>
+<p>
+  As defined in <a href="http://tools.ietf.org/html/draft-zyp-json-schema-03">
+  http://tools.ietf.org/html/draft-zyp-json-schema-03</a>.
+</p>
+
+
+    <h4>
+      <a name="Schema.ApiError">ApiError</a> (<a href="#Type.ApiError">type</a>)
+    </h4>
+    <pre>{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ApiError">ApiError</A>"<span id="toggle.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError.ApiError.27.ApiError" style="display:none">{
+  "id": "ApiError", 
+  "module_id": "Common", 
+  "properties": {
+    "details": {
+      "title": "Further details about the error", 
+      "type": "string"
+    }, 
+    "error_code": {
+      "title": "A numeric error code", 
+      "type": "integer"
+    }, 
+    "error_data": {
+      "title": "Additional data about the error", 
+      "type": "object"
+    }, 
+    "error_message": {
+      "title": "A description of the error", 
+      "type": "string"
+    }, 
+    "module_name": {
+      "title": "The module name where the error occurred", 
+      "type": "string"
+    }, 
+    "related_errors": {
+      "items": {
+        "$ref": "ApiError"
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</span>
+      }, 
+      "title": "Other errors related to this error", 
+      "type": "array"
+    }
+  }, 
+  "title": "Detailed information about an API error", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.BGPRoutes">BGPRoutes</a> (<a href="#Type.BGPRoutes">type</a>)
+    </h4>
+    <pre>{
+  "id": "BGPRoutes", 
+  "module_id": "VMC", 
+  "properties": {
+    "bgp_routes": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.BGPRoutes.7.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.BGPRoutes.7.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "BGP routes", 
+      "type": "array"
+    }
+  }, 
+  "title": "BGP routes", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.ConnectedServiceListResult">ConnectedServiceListResult</a> (<a href="#Type.ConnectedServiceListResult">type</a>)
+    </h4>
+    <pre>{
+  "description": "A list of status of 'Enabled/Disabled' for a service connected to a linked vpc", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.4.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.4.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ConnectedServiceListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.24.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.24.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ConnectedServiceListResult.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.ConnectedServiceStatus">ConnectedServiceStatus</A>"<span id="toggle.schema.ConnectedServiceListResult.40.ConnectedServiceStatus" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ConnectedServiceListResult.40.ConnectedServiceStatus" style="display:none">{
+  "description": "Status of 'Enabled/Disabled' for a service connected to a linked vpc", 
+  "id": "ConnectedServiceStatus", 
+  "module_id": "VMC", 
+  "properties": {
+    "enabled": {
+      "readonly": true, 
+      "required": true, 
+      "title": "status of service", 
+      "type": "boolean"
+    }, 
+    "name": {
+      "readonly": true, 
+      "required": true, 
+      "title": "service name", 
+      "type": "string"
+    }
+  }, 
+  "title": "Connected service status", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Connected service status list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "List result for connected service(s) related to a linked vpc", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.ConnectedServiceStatus">ConnectedServiceStatus</a> (<a href="#Type.ConnectedServiceStatus">type</a>)
+    </h4>
+    <pre>{
+  "description": "Status of 'Enabled/Disabled' for a service connected to a linked vpc", 
+  "id": "ConnectedServiceStatus", 
+  "module_id": "VMC", 
+  "properties": {
+    "enabled": {
+      "readonly": true, 
+      "required": true, 
+      "title": "status of service", 
+      "type": "boolean"
+    }, 
+    "name": {
+      "readonly": true, 
+      "required": true, 
+      "title": "service name", 
+      "type": "string"
+    }
+  }, 
+  "title": "Connected service status", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.DeleteRequestParameters">DeleteRequestParameters</a> (<a href="#Type.DeleteRequestParameters">type</a>)
+    </h4>
+    <pre>{
+  "additionalProperties": {}, 
+  "id": "DeleteRequestParameters", 
+  "module_id": "Common", 
+  "properties": {
+    "force": {
+      "default": false, 
+      "description": "If true, deleting the resource succeeds even if it is being\nreferred as a resource reference.\n", 
+      "title": "Force delete the resource even if it is being used somewhere\n", 
+      "type": "boolean"
+    }
+  }, 
+  "title": "Parameters that affect how delete operations are processed", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.DiscoveredResource">DiscoveredResource</a> (<a href="#Type.DiscoveredResource">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.DiscoveredResource.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.DiscoveredResource.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.DiscoveredResource.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.DiscoveredResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "DiscoveredResource", 
+  "module_id": "Common", 
+  "polymorphic-type-descriptor": {
+    "property-name": "resource_type"
+  }, 
+  "properties": {
+    "_last_sync_time": {
+      "$ref": "<A HREF="#Schema.EpochMsTimestamp">EpochMsTimestamp</A>"<span id="toggle.schema.DiscoveredResource.13.EpochMsTimestamp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.13.EpochMsTimestamp" style="display:none">{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</span>, 
+      "can_sort": true, 
+      "description": "Timestamp of last modification", 
+      "readonly": true
+    }, 
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.DiscoveredResource.21.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.21.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.DiscoveredResource.33.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.33.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.DiscoveredResource.33.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.33.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "description": {
+      "can_sort": true, 
+      "maxLength": 1024, 
+      "title": "Description of this resource", 
+      "type": "string"
+    }, 
+    "display_name": {
+      "can_sort": true, 
+      "description": "Defaults to ID if not set", 
+      "maxLength": 255, 
+      "title": "Identifier to use when displaying entity in logs or GUI", 
+      "type": "string"
+    }, 
+    "resource_type": {
+      "description": "The type of this resource.", 
+      "readonly": false, 
+      "type": "string"
+    }, 
+    "tags": {
+      "items": {
+        "$ref": "<A HREF="#Schema.Tag">Tag</A>"<span id="toggle.schema.DiscoveredResource.57.Tag" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.DiscoveredResource.57.Tag" style="display:none">{
+  "id": "Tag", 
+  "module_id": "Common", 
+  "properties": {
+    "scope": {
+      "default": "", 
+      "description": "Tag searches may optionally be restricted by scope", 
+      "display": {
+        "order": 1
+      }, 
+      "maxLength": 30, 
+      "readonly": false, 
+      "title": "Tag scope", 
+      "type": "string"
+    }, 
+    "tag": {
+      "default": "", 
+      "description": "Identifier meaningful to user", 
+      "display": {
+        "order": 2
+      }, 
+      "maxLength": 65, 
+      "readonly": false, 
+      "title": "Tag value", 
+      "type": "string"
+    }
+  }, 
+  "title": "Arbitrary key-value pairs that may be attached to an entity", 
+  "type": "object"
+}
+</span>
+      }, 
+      "maxItems": 30, 
+      "title": "Opaque identifiers meaningful to the API user", 
+      "type": "array"
+    }
+  }, 
+  "title": "Base class for resources that are discovered and automatically updated", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.EmbeddedResource">EmbeddedResource</a> (<a href="#Type.EmbeddedResource">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.RevisionedResource">RevisionedResource</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource" style="display:none">{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "RevisionedResource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_revision": {
+      "description": "The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.", 
+      "readonly": true, 
+      "title": "Generation of this resource config", 
+      "type": "int"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "A base class for types that track revisions", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "EmbeddedResource", 
+  "module_id": "Common", 
+  "polymorphic-type-descriptor": {
+    "property-name": "resource_type"
+  }, 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.15.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.15.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_owner": {
+      "$ref": "<A HREF="#Schema.OwnerResourceLink">OwnerResourceLink</A>"<span id="toggle.schema.EmbeddedResource.22.OwnerResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.22.OwnerResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.22.OwnerResourceLink.OwnerResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.22.OwnerResourceLink.OwnerResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "OwnerResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Owner of this resource"
+    }, 
+    "_revision": {
+      "description": "The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.", 
+      "readonly": true, 
+      "title": "Generation of this resource config", 
+      "type": "int"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.EmbeddedResource.38.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.38.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.EmbeddedResource.38.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.EmbeddedResource.38.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "description": {
+      "can_sort": true, 
+      "maxLength": 1024, 
+      "title": "Description of this resource", 
+      "type": "string"
+    }, 
+    "display_name": {
+      "can_sort": true, 
+      "description": "Defaults to ID if not set", 
+      "maxLength": 255, 
+      "title": "Identifier to use when displaying entity in logs or GUI", 
+      "type": "string"
+    }, 
+    "id": {
+      "description": "Identifier of the resource", 
+      "readonly": true, 
+      "required": false, 
+      "type": "string"
+    }, 
+    "resource_type": {
+      "description": "The type of this resource.", 
+      "readonly": false, 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for resources that are embedded in other resources", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.EpochMsTimestamp">EpochMsTimestamp</a> (<a href="#Type.EpochMsTimestamp">type</a>)
+    </h4>
+    <pre>{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.IPv4Address">IPv4Address</a> (<a href="#Type.IPv4Address">type</a>)
+    </h4>
+    <pre>{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.IPv4CIDRBlock">IPv4CIDRBlock</a> (<a href="#Type.IPv4CIDRBlock">type</a>)
+    </h4>
+    <pre>{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.InterfaceStatistics">InterfaceStatistics</a> (<a href="#Type.InterfaceStatistics">type</a>)
+    </h4>
+    <pre>{
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.InterfaceStatistics.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "InterfaceStatistics", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.24.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.24.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.InterfaceStatistics.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.InterfaceStatistics.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "rx_bytes": {
+      "display": {
+        "order": 1
+      }, 
+      "readonly": true, 
+      "title": "Count of bytes received on this port", 
+      "type": "integer"
+    }, 
+    "rx_errors": {
+      "display": {
+        "order": 5
+      }, 
+      "readonly": true, 
+      "title": "Count of receive errors occurring on this port", 
+      "type": "integer"
+    }, 
+    "rx_packets": {
+      "display": {
+        "order": 2
+      }, 
+      "readonly": true, 
+      "title": "Count of packets received on this port", 
+      "type": "integer"
+    }, 
+    "tx_bytes": {
+      "display": {
+        "order": 3
+      }, 
+      "readonly": true, 
+      "title": "Count of bytes transmitted on this port", 
+      "type": "integer"
+    }, 
+    "tx_errors": {
+      "display": {
+        "order": 6
+      }, 
+      "readonly": true, 
+      "title": "Count of transmit errors occurring on this port", 
+      "type": "integer"
+    }, 
+    "tx_packets": {
+      "display": {
+        "order": 4
+      }, 
+      "readonly": true, 
+      "title": "Count of packets transmitted on this port", 
+      "type": "integer"
+    }
+  }, 
+  "title": "Statistics for a network interface", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.IpAttachmentPair">IpAttachmentPair</a> (<a href="#Type.IpAttachmentPair">type</a>)
+    </h4>
+    <pre>{
+  "id": "IpAttachmentPair", 
+  "module_id": "VMC", 
+  "properties": {
+    "attachment_id": {
+      "required": true, 
+      "title": "Attachment id which maps to management VM IP", 
+      "type": "string"
+    }, 
+    "ip": {
+      "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.IpAttachmentPair.11.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.IpAttachmentPair.11.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>, 
+      "required": true, 
+      "title": "Management VM IP Address"
+    }
+  }, 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.LinkedVpcInfo">LinkedVpcInfo</a> (<a href="#Type.LinkedVpcInfo">type</a>)
+    </h4>
+    <pre>{
+  "id": "LinkedVpcInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "arn_role": {
+      "required": true, 
+      "title": "ARN role for linked VPC operations", 
+      "type": "string"
+    }, 
+    "external_id": {
+      "required": true, 
+      "title": "External identifier for ARN role", 
+      "type": "string"
+    }, 
+    "linked_account": {
+      "required": true, 
+      "title": "Linked VPC account number", 
+      "type": "string"
+    }, 
+    "linked_vpc_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.LinkedVpcInfo.22.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcInfo.22.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Linked VPC CIDRs", 
+      "type": "array"
+    }, 
+    "linked_vpc_id": {
+      "required": false, 
+      "title": "Linked VPC identifier", 
+      "type": "string"
+    }, 
+    "linked_vpc_nat_ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.LinkedVpcInfo.35.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcInfo.35.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "The IPs of linked VPC NAT rule for service access.", 
+      "type": "array"
+    }, 
+    "linked_vpc_subnet_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.LinkedVpcInfo.43.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcInfo.43.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Linked VPC ENIs subnet CIDRs", 
+      "type": "array"
+    }, 
+    "route_table_ids": {
+      "items": {
+        "type": "string"
+      }, 
+      "required": true, 
+      "title": "The identifiers of route tables to be dynamically updated with SDDC networks", 
+      "type": "array"
+    }, 
+    "service_arn_role": {
+      "required": false, 
+      "title": "service ARN role", 
+      "type": "string"
+    }
+  }, 
+  "title": "Linked VPC info", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.LinkedVpcsListResult">LinkedVpcsListResult</a> (<a href="#Type.LinkedVpcsListResult">type</a>)
+    </h4>
+    <pre>{
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "LinkedVpcsListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.11.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.11.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.23.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.23.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.LinkedVpcsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.LinkedVpcInfo">LinkedVpcInfo</A>"<span id="toggle.schema.LinkedVpcsListResult.39.LinkedVpcInfo" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.39.LinkedVpcInfo" style="display:none">{
+  "id": "LinkedVpcInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "arn_role": {
+      "required": true, 
+      "title": "ARN role for linked VPC operations", 
+      "type": "string"
+    }, 
+    "external_id": {
+      "required": true, 
+      "title": "External identifier for ARN role", 
+      "type": "string"
+    }, 
+    "linked_account": {
+      "required": true, 
+      "title": "Linked VPC account number", 
+      "type": "string"
+    }, 
+    "linked_vpc_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.22.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.22.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Linked VPC CIDRs", 
+      "type": "array"
+    }, 
+    "linked_vpc_id": {
+      "required": false, 
+      "title": "Linked VPC identifier", 
+      "type": "string"
+    }, 
+    "linked_vpc_nat_ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.35.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.35.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "The IPs of linked VPC NAT rule for service access.", 
+      "type": "array"
+    }, 
+    "linked_vpc_subnet_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.43.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.LinkedVpcsListResult.39.LinkedVpcInfo.LinkedVpcInfo.43.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Linked VPC ENIs subnet CIDRs", 
+      "type": "array"
+    }, 
+    "route_table_ids": {
+      "items": {
+        "type": "string"
+      }, 
+      "required": true, 
+      "title": "The identifiers of route tables to be dynamically updated with SDDC networks", 
+      "type": "array"
+    }, 
+    "service_arn_role": {
+      "required": false, 
+      "title": "service ARN role", 
+      "type": "string"
+    }
+  }, 
+  "title": "Linked VPC info", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Linked VPCs list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Linked VPC list query result", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.ListResult">ListResult</a> (<a href="#Type.ListResult">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.ManagedResource">ManagedResource</a> (<a href="#Type.ManagedResource">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.RevisionedResource">RevisionedResource</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource" style="display:none">{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "RevisionedResource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_revision": {
+      "description": "The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.", 
+      "readonly": true, 
+      "title": "Generation of this resource config", 
+      "type": "int"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.4.RevisionedResource.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "A base class for types that track revisions", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ManagedResource", 
+  "module_id": "Common", 
+  "polymorphic-type-descriptor": {
+    "property-name": "resource_type"
+  }, 
+  "properties": {
+    "_create_time": {
+      "$ref": "<A HREF="#Schema.EpochMsTimestamp">EpochMsTimestamp</A>"<span id="toggle.schema.ManagedResource.13.EpochMsTimestamp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.13.EpochMsTimestamp" style="display:none">{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</span>, 
+      "can_sort": true, 
+      "description": "Timestamp of resource creation", 
+      "readonly": true
+    }, 
+    "_create_user": {
+      "description": "ID of the user who created this resource", 
+      "readonly": true, 
+      "type": "string"
+    }, 
+    "_last_modified_time": {
+      "$ref": "<A HREF="#Schema.EpochMsTimestamp">EpochMsTimestamp</A>"<span id="toggle.schema.ManagedResource.24.EpochMsTimestamp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.24.EpochMsTimestamp" style="display:none">{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</span>, 
+      "can_sort": true, 
+      "description": "Timestamp of last modification", 
+      "readonly": true
+    }, 
+    "_last_modified_user": {
+      "description": "ID of the user who last modified this resource", 
+      "readonly": true, 
+      "type": "string"
+    }, 
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.37.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.37.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_protection": {
+      "description": "Protection status is one of the following:\nPROTECTED - the client who retrieved the entity is not allowed\n            to modify it.\nNOT_PROTECTED - the client who retrieved the entity is allowed\n                to modify it\nREQUIRE_OVERRIDE - the client who retrieved the entity is a super\n                   user and can modify it, but only when providing\n                   the request header X-Allow-Overwrite=true.\nUNKNOWN - the _protection field could not be determined for this\n          entity.\n", 
+      "readonly": true, 
+      "title": "Indicates protection status of this resource", 
+      "type": "string"
+    }, 
+    "_revision": {
+      "description": "The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.", 
+      "readonly": true, 
+      "title": "Generation of this resource config", 
+      "type": "int"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.ManagedResource.61.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.61.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.ManagedResource.61.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.61.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "_system_owned": {
+      "description": "Indicates system owned resource", 
+      "readonly": true, 
+      "type": "boolean"
+    }, 
+    "description": {
+      "can_sort": true, 
+      "maxLength": 1024, 
+      "title": "Description of this resource", 
+      "type": "string"
+    }, 
+    "display_name": {
+      "can_sort": true, 
+      "description": "Defaults to ID if not set", 
+      "maxLength": 255, 
+      "title": "Identifier to use when displaying entity in logs or GUI", 
+      "type": "string"
+    }, 
+    "id": {
+      "can_sort": true, 
+      "readonly": true, 
+      "title": "Unique identifier of this resource", 
+      "type": "string"
+    }, 
+    "resource_type": {
+      "description": "The type of this resource.", 
+      "readonly": false, 
+      "type": "string"
+    }, 
+    "tags": {
+      "items": {
+        "$ref": "<A HREF="#Schema.Tag">Tag</A>"<span id="toggle.schema.ManagedResource.96.Tag" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.ManagedResource.96.Tag" style="display:none">{
+  "id": "Tag", 
+  "module_id": "Common", 
+  "properties": {
+    "scope": {
+      "default": "", 
+      "description": "Tag searches may optionally be restricted by scope", 
+      "display": {
+        "order": 1
+      }, 
+      "maxLength": 30, 
+      "readonly": false, 
+      "title": "Tag scope", 
+      "type": "string"
+    }, 
+    "tag": {
+      "default": "", 
+      "description": "Identifier meaningful to user", 
+      "display": {
+        "order": 2
+      }, 
+      "maxLength": 65, 
+      "readonly": false, 
+      "title": "Tag value", 
+      "type": "string"
+    }
+  }, 
+  "title": "Arbitrary key-value pairs that may be attached to an entity", 
+  "type": "object"
+}
+</span>
+      }, 
+      "maxItems": 30, 
+      "title": "Opaque identifiers meaningful to the API user", 
+      "type": "array"
+    }
+  }, 
+  "title": "Base type for resources that are managed by API clients", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.MgmtServiceEntry">MgmtServiceEntry</a> (<a href="#Type.MgmtServiceEntry">type</a>)
+    </h4>
+    <pre>{
+  "description": "Service entry describes the detail of a network service. Either a existing\nservice path or TCP/UDP/ICMP protocol/ports details could be specified.\n", 
+  "id": "MgmtServiceEntry", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "required": false, 
+      "title": "Display name for this service", 
+      "type": "string"
+    }, 
+    "name": {
+      "description": "Service entry name which was based on protocol 'TCP'. The good\nexample is 'HTTP', 'HTTPS' etc. If no specification, a default\nname will be generated in format protocol_port, ex. 'TCP_8080'.\n", 
+      "required": false, 
+      "title": "Name of service entry", 
+      "type": "string"
+    }, 
+    "path": {
+      "required": false, 
+      "title": "Service path in policy manager", 
+      "type": "string"
+    }, 
+    "ports": {
+      "description": "Service ports is required if resource_type is 'TCPEntry' or 'UDPEntry'.\n", 
+      "items": {
+        "maximum": 65535, 
+        "minimum": 0, 
+        "type": "int"
+      }, 
+      "required": false, 
+      "title": "Ports to provide this service", 
+      "type": "array"
+    }, 
+    "resource_type": {
+      "enum": [
+        "ICMPEntry", 
+        "TCPEntry", 
+        "UDPEntry"
+      ], 
+      "required": false, 
+      "type": "string"
+    }
+  }, 
+  "title": "Management VM service entry", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.MgmtVmInfo">MgmtVmInfo</a> (<a href="#Type.MgmtVmInfo">type</a>)
+    </h4>
+    <pre>{
+  "id": "MgmtVmInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "readonly": false, 
+      "required": false, 
+      "title": "Management VM name", 
+      "type": "string"
+    }, 
+    "group_path": {
+      "description": "For each management VM, a dedicated policy group will be created.\nThis property will reflect its group path.\n", 
+      "readonly": true, 
+      "required": false, 
+      "title": "Group path in policy manager", 
+      "type": "string"
+    }, 
+    "id": {
+      "readonly": true, 
+      "required": false, 
+      "title": "Management VM identifier", 
+      "type": "string"
+    }, 
+    "ip_attachment_pairs": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IpAttachmentPair">IpAttachmentPair</A>"<span id="toggle.schema.MgmtVmInfo.26.IpAttachmentPair" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmInfo.26.IpAttachmentPair" style="display:none">{
+  "id": "IpAttachmentPair", 
+  "module_id": "VMC", 
+  "properties": {
+    "attachment_id": {
+      "required": true, 
+      "title": "Attachment id which maps to management VM IP", 
+      "type": "string"
+    }, 
+    "ip": {
+      "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.MgmtVmInfo.26.IpAttachmentPair.IpAttachmentPair.11.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmInfo.26.IpAttachmentPair.IpAttachmentPair.11.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>, 
+      "required": true, 
+      "title": "Management VM IP Address"
+    }
+  }, 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "IP address and attachment id pairs for tagging managment VM", 
+      "type": "array"
+    }, 
+    "ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.MgmtVmInfo.34.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmInfo.34.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Local IPs of a management VM", 
+      "type": "array"
+    }, 
+    "services": {
+      "description": "Details about protocols and ports which services will be provided.\n", 
+      "items": {
+        "$ref": "<A HREF="#Schema.MgmtServiceEntry">MgmtServiceEntry</A>"<span id="toggle.schema.MgmtVmInfo.43.MgmtServiceEntry" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmInfo.43.MgmtServiceEntry" style="display:none">{
+  "description": "Service entry describes the detail of a network service. Either a existing\nservice path or TCP/UDP/ICMP protocol/ports details could be specified.\n", 
+  "id": "MgmtServiceEntry", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "required": false, 
+      "title": "Display name for this service", 
+      "type": "string"
+    }, 
+    "name": {
+      "description": "Service entry name which was based on protocol 'TCP'. The good\nexample is 'HTTP', 'HTTPS' etc. If no specification, a default\nname will be generated in format protocol_port, ex. 'TCP_8080'.\n", 
+      "required": false, 
+      "title": "Name of service entry", 
+      "type": "string"
+    }, 
+    "path": {
+      "required": false, 
+      "title": "Service path in policy manager", 
+      "type": "string"
+    }, 
+    "ports": {
+      "description": "Service ports is required if resource_type is 'TCPEntry' or 'UDPEntry'.\n", 
+      "items": {
+        "maximum": 65535, 
+        "minimum": 0, 
+        "type": "int"
+      }, 
+      "required": false, 
+      "title": "Ports to provide this service", 
+      "type": "array"
+    }, 
+    "resource_type": {
+      "enum": [
+        "ICMPEntry", 
+        "TCPEntry", 
+        "UDPEntry"
+      ], 
+      "required": false, 
+      "type": "string"
+    }
+  }, 
+  "title": "Management VM service entry", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Services which will be provided in this management VM", 
+      "type": "array"
+    }
+  }, 
+  "title": "Management VM access information", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.MgmtVmsListResult">MgmtVmsListResult</a> (<a href="#Type.MgmtVmsListResult">type</a>)
+    </h4>
+    <pre>{
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "MgmtVmsListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.11.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.11.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.23.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.23.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.MgmtVmsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.MgmtVmInfo">MgmtVmInfo</A>"<span id="toggle.schema.MgmtVmsListResult.39.MgmtVmInfo" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.39.MgmtVmInfo" style="display:none">{
+  "id": "MgmtVmInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "readonly": false, 
+      "required": false, 
+      "title": "Management VM name", 
+      "type": "string"
+    }, 
+    "group_path": {
+      "description": "For each management VM, a dedicated policy group will be created.\nThis property will reflect its group path.\n", 
+      "readonly": true, 
+      "required": false, 
+      "title": "Group path in policy manager", 
+      "type": "string"
+    }, 
+    "id": {
+      "readonly": true, 
+      "required": false, 
+      "title": "Management VM identifier", 
+      "type": "string"
+    }, 
+    "ip_attachment_pairs": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IpAttachmentPair">IpAttachmentPair</A>"<span id="toggle.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.26.IpAttachmentPair" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.26.IpAttachmentPair" style="display:none">{
+  "id": "IpAttachmentPair", 
+  "module_id": "VMC", 
+  "properties": {
+    "attachment_id": {
+      "required": true, 
+      "title": "Attachment id which maps to management VM IP", 
+      "type": "string"
+    }, 
+    "ip": {
+      "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.26.IpAttachmentPair.IpAttachmentPair.11.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.26.IpAttachmentPair.IpAttachmentPair.11.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>, 
+      "required": true, 
+      "title": "Management VM IP Address"
+    }
+  }, 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "IP address and attachment id pairs for tagging managment VM", 
+      "type": "array"
+    }, 
+    "ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.34.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.34.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Local IPs of a management VM", 
+      "type": "array"
+    }, 
+    "services": {
+      "description": "Details about protocols and ports which services will be provided.\n", 
+      "items": {
+        "$ref": "<A HREF="#Schema.MgmtServiceEntry">MgmtServiceEntry</A>"<span id="toggle.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.43.MgmtServiceEntry" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.MgmtVmsListResult.39.MgmtVmInfo.MgmtVmInfo.43.MgmtServiceEntry" style="display:none">{
+  "description": "Service entry describes the detail of a network service. Either a existing\nservice path or TCP/UDP/ICMP protocol/ports details could be specified.\n", 
+  "id": "MgmtServiceEntry", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "required": false, 
+      "title": "Display name for this service", 
+      "type": "string"
+    }, 
+    "name": {
+      "description": "Service entry name which was based on protocol 'TCP'. The good\nexample is 'HTTP', 'HTTPS' etc. If no specification, a default\nname will be generated in format protocol_port, ex. 'TCP_8080'.\n", 
+      "required": false, 
+      "title": "Name of service entry", 
+      "type": "string"
+    }, 
+    "path": {
+      "required": false, 
+      "title": "Service path in policy manager", 
+      "type": "string"
+    }, 
+    "ports": {
+      "description": "Service ports is required if resource_type is 'TCPEntry' or 'UDPEntry'.\n", 
+      "items": {
+        "maximum": 65535, 
+        "minimum": 0, 
+        "type": "int"
+      }, 
+      "required": false, 
+      "title": "Ports to provide this service", 
+      "type": "array"
+    }, 
+    "resource_type": {
+      "enum": [
+        "ICMPEntry", 
+        "TCPEntry", 
+        "UDPEntry"
+      ], 
+      "required": false, 
+      "type": "string"
+    }
+  }, 
+  "title": "Management VM service entry", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Services which will be provided in this management VM", 
+      "type": "array"
+    }
+  }, 
+  "title": "Management VM access information", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Management VMs list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Management VM list query result", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.NoRestRequestParameters">NoRestRequestParameters</a> (<a href="#Type.NoRestRequestParameters">type</a>)
+    </h4>
+    <pre>{
+  "additionalProperties": false, 
+  "description": "Parameter definition for requests that do not allow parameters.", 
+  "id": "NoRestRequestParameters", 
+  "module_id": "Types", 
+  "properties": {}, 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.OwnerResourceLink">OwnerResourceLink</a> (<a href="#Type.OwnerResourceLink">type</a>)
+    </h4>
+    <pre>{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.OwnerResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.OwnerResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "OwnerResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.PrefixInfo">PrefixInfo</a> (<a href="#Type.PrefixInfo">type</a>)
+    </h4>
+    <pre>{
+  "id": "PrefixInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Display name", 
+      "type": "string"
+    }, 
+    "prefixes": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.PrefixInfo.13.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixInfo.13.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Service IP prefixes", 
+      "type": "array"
+    }
+  }, 
+  "title": "Service IP prefixes information", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.PrefixesListResult">PrefixesListResult</a> (<a href="#Type.PrefixesListResult">type</a>)
+    </h4>
+    <pre>{
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "PrefixesListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.11.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.11.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PrefixesListResult.23.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.23.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PrefixesListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.PrefixInfo">PrefixInfo</A>"<span id="toggle.schema.PrefixesListResult.39.PrefixInfo" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.39.PrefixInfo" style="display:none">{
+  "id": "PrefixInfo", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Display name", 
+      "type": "string"
+    }, 
+    "prefixes": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.PrefixesListResult.39.PrefixInfo.PrefixInfo.13.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PrefixesListResult.39.PrefixInfo.PrefixInfo.13.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Service IP prefixes", 
+      "type": "array"
+    }
+  }, 
+  "title": "Service IP prefixes information", 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Service Prefixes list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Service Prefix list query result", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.PublicIp">PublicIp</a> (<a href="#Type.PublicIp">type</a>)
+    </h4>
+    <pre>{
+  "id": "PublicIp", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "required": false, 
+      "type": "string"
+    }, 
+    "id": {
+      "readonly": true, 
+      "required": false, 
+      "title": "Public IP identifier", 
+      "type": "string"
+    }, 
+    "ip": {
+      "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.PublicIp.16.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIp.16.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>, 
+      "readonly": true, 
+      "required": false
+    }
+  }, 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.PublicIpsListResult">PublicIpsListResult</a> (<a href="#Type.PublicIpsListResult">type</a>)
+    </h4>
+    <pre>{
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "PublicIpsListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.11.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.11.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.23.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.23.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.PublicIpsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.PublicIp">PublicIp</A>"<span id="toggle.schema.PublicIpsListResult.39.PublicIp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.39.PublicIp" style="display:none">{
+  "id": "PublicIp", 
+  "module_id": "VMC", 
+  "properties": {
+    "display_name": {
+      "required": false, 
+      "type": "string"
+    }, 
+    "id": {
+      "readonly": true, 
+      "required": false, 
+      "title": "Public IP identifier", 
+      "type": "string"
+    }, 
+    "ip": {
+      "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.PublicIpsListResult.39.PublicIp.PublicIp.16.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.PublicIpsListResult.39.PublicIp.PublicIp.16.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>, 
+      "readonly": true, 
+      "required": false
+    }
+  }, 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Public IP list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Public IP list", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.Resource">Resource</a> (<a href="#Type.Resource">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.ResourceLink">ResourceLink</a> (<a href="#Type.ResourceLink">type</a>)
+    </h4>
+    <pre>{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.RevisionedResource">RevisionedResource</a> (<a href="#Type.RevisionedResource">type</a>)
+    </h4>
+    <pre>{
+  "abstract": true, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.RevisionedResource.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.RevisionedResource.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "RevisionedResource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.RevisionedResource.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_revision": {
+      "description": "The _revision property describes the current revision of the resource. To prevent clients from overwriting each other's changes, PUT operations must include the current _revision of the resource, which clients should obtain by issuing a GET operation. If the _revision provided in a PUT request is missing or stale, the operation will be rejected.", 
+      "readonly": true, 
+      "title": "Generation of this resource config", 
+      "type": "int"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.RevisionedResource.30.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.30.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.RevisionedResource.30.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "A base class for types that track revisions", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.SddcUserConfiguration">SddcUserConfiguration</a> (<a href="#Type.SddcUserConfiguration">type</a>)
+    </h4>
+    <pre>{
+  "description": "SDDC configuration parameters for users. User-level addresses/CIDRs are provided.", 
+  "id": "SddcUserConfiguration", 
+  "module_id": "VMC", 
+  "properties": {
+    "compute_gateway": {
+      "required": true, 
+      "title": "Compute gateway name", 
+      "type": "string"
+    }, 
+    "dx_interface_label": {
+      "required": true, 
+      "title": "DirectConnect interface label name", 
+      "type": "string"
+    }, 
+    "linked_vpc_interface_label": {
+      "required": true, 
+      "title": "Linked VPC interface label name", 
+      "type": "string"
+    }, 
+    "management_gateway": {
+      "required": true, 
+      "title": "Management gateway name", 
+      "type": "string"
+    }, 
+    "mgmt_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.SddcUserConfiguration.28.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.SddcUserConfiguration.28.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "Management VMs CIDRs", 
+      "type": "array"
+    }, 
+    "provider_name": {
+      "required": true, 
+      "title": "Provider Name", 
+      "type": "string"
+    }, 
+    "public_interface_label": {
+      "required": true, 
+      "title": "Public interface label name", 
+      "type": "string"
+    }, 
+    "sddc_infra_addresses": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4CIDRBlock">IPv4CIDRBlock</A>"<span id="toggle.schema.SddcUserConfiguration.46.IPv4CIDRBlock" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.SddcUserConfiguration.46.IPv4CIDRBlock" style="display:none">{
+  "format": "ipv4-cidr-block", 
+  "id": "IPv4CIDRBlock", 
+  "module_id": "Common", 
+  "title": "IPv4 CIDR Block", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": true, 
+      "title": "SDDC Infra CIDRs", 
+      "type": "array"
+    }, 
+    "vpn_dx_ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.SddcUserConfiguration.54.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.SddcUserConfiguration.54.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Local IPs for VPN tunnel over Direct Connect", 
+      "type": "array"
+    }, 
+    "vpn_internet_ips": {
+      "items": {
+        "$ref": "<A HREF="#Schema.IPv4Address">IPv4Address</A>"<span id="toggle.schema.SddcUserConfiguration.62.IPv4Address" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.SddcUserConfiguration.62.IPv4Address" style="display:none">{
+  "format": "ipv4", 
+  "id": "IPv4Address", 
+  "module_id": "Common", 
+  "title": "IPv4 address", 
+  "type": "string"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "Public IPs for VPN tunnel over internet", 
+      "type": "array"
+    }
+  }, 
+  "title": "SDDC configuration parameters for users", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.SelfResourceLink">SelfResourceLink</a> (<a href="#Type.SelfResourceLink">type</a>)
+    </h4>
+    <pre>{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.Tag">Tag</a> (<a href="#Type.Tag">type</a>)
+    </h4>
+    <pre>{
+  "id": "Tag", 
+  "module_id": "Common", 
+  "properties": {
+    "scope": {
+      "default": "", 
+      "description": "Tag searches may optionally be restricted by scope", 
+      "display": {
+        "order": 1
+      }, 
+      "maxLength": 30, 
+      "readonly": false, 
+      "title": "Tag scope", 
+      "type": "string"
+    }, 
+    "tag": {
+      "default": "", 
+      "description": "Identifier meaningful to user", 
+      "display": {
+        "order": 2
+      }, 
+      "maxLength": 65, 
+      "readonly": false, 
+      "title": "Tag value", 
+      "type": "string"
+    }
+  }, 
+  "title": "Arbitrary key-value pairs that may be attached to an entity", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.TaskProperties">TaskProperties</a> (<a href="#Type.TaskProperties">type</a>)
+    </h4>
+    <pre>{
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.TaskProperties.4.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.4.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.TaskProperties.4.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.4.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.TaskProperties.4.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.4.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.TaskProperties.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.4.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "TaskProperties", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.TaskProperties.12.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.12.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.TaskProperties.24.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.24.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.TaskProperties.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.24.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "async_response_available": {
+      "display": {
+        "order": 13
+      }, 
+      "readonly": true, 
+      "title": "True if response for asynchronous request is available", 
+      "type": "boolean"
+    }, 
+    "cancelable": {
+      "display": {
+        "order": 8
+      }, 
+      "readonly": true, 
+      "title": "True if this task can be canceled", 
+      "type": "boolean"
+    }, 
+    "description": {
+      "display": {
+        "order": 2
+      }, 
+      "readonly": true, 
+      "title": "Description of the task", 
+      "type": "string"
+    }, 
+    "end_time": {
+      "$ref": "<A HREF="#Schema.EpochMsTimestamp">EpochMsTimestamp</A>"<span id="toggle.schema.TaskProperties.53.EpochMsTimestamp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.53.EpochMsTimestamp" style="display:none">{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</span>, 
+      "display": {
+        "order": 6
+      }, 
+      "readonly": true, 
+      "title": "The end time of the task in epoch milliseconds"
+    }, 
+    "id": {
+      "display": {
+        "order": 1
+      }, 
+      "readonly": true, 
+      "title": "Identifier for this task", 
+      "type": "string"
+    }, 
+    "message": {
+      "display": {
+        "order": 4
+      }, 
+      "readonly": true, 
+      "title": "A message describing the disposition of the task", 
+      "type": "string"
+    }, 
+    "progress": {
+      "display": {
+        "order": 7
+      }, 
+      "maximum": 100, 
+      "minimum": 0, 
+      "readonly": true, 
+      "title": "Task progress if known, from 0 to 100", 
+      "type": "integer"
+    }, 
+    "request_method": {
+      "display": {
+        "order": 12
+      }, 
+      "readonly": true, 
+      "title": "HTTP request method", 
+      "type": "string"
+    }, 
+    "request_uri": {
+      "display": {
+        "order": 11
+      }, 
+      "readonly": true, 
+      "title": "URI of the method invocation that spawned this task", 
+      "type": "string"
+    }, 
+    "start_time": {
+      "$ref": "<A HREF="#Schema.EpochMsTimestamp">EpochMsTimestamp</A>"<span id="toggle.schema.TaskProperties.103.EpochMsTimestamp" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.103.EpochMsTimestamp" style="display:none">{
+  "id": "EpochMsTimestamp", 
+  "module_id": "Common", 
+  "title": "Timestamp in milliseconds since epoch", 
+  "type": "integer"
+}
+</span>, 
+      "display": {
+        "order": 5
+      }, 
+      "readonly": true, 
+      "title": "The start time of the task in epoch milliseconds"
+    }, 
+    "status": {
+      "$ref": "<A HREF="#Schema.TaskStatus">TaskStatus</A>"<span id="toggle.schema.TaskProperties.111.TaskStatus" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.TaskProperties.111.TaskStatus" style="display:none">{
+  "enum": [
+    "running", 
+    "error", 
+    "success", 
+    "canceling", 
+    "canceled", 
+    "killed"
+  ], 
+  "id": "TaskStatus", 
+  "module_id": "Common", 
+  "title": "Current status of the task", 
+  "type": "string"
+}
+</span>, 
+      "display": {
+        "order": 3
+      }, 
+      "readonly": true, 
+      "title": "Current status of the task"
+    }, 
+    "user": {
+      "display": {
+        "order": 10
+      }, 
+      "readonly": true, 
+      "title": "Name of the user who created this task", 
+      "type": "string"
+    }
+  }, 
+  "title": "Task properties", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.TaskStatus">TaskStatus</a> (<a href="#Type.TaskStatus">type</a>)
+    </h4>
+    <pre>{
+  "enum": [
+    "running", 
+    "error", 
+    "success", 
+    "canceling", 
+    "canceled", 
+    "killed"
+  ], 
+  "id": "TaskStatus", 
+  "module_id": "Common", 
+  "title": "Current status of the task", 
+  "type": "string"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.VMCAccounts">VMCAccounts</a> (<a href="#Type.VMCAccounts">type</a>)
+    </h4>
+    <pre>{
+  "id": "VMCAccounts", 
+  "module_id": "VMC", 
+  "properties": {
+    "linked_vpc_account": {
+      "required": false, 
+      "title": "linked VPC account number", 
+      "type": "string"
+    }, 
+    "shadow_account": {
+      "required": true, 
+      "title": "Shadow VPC account number", 
+      "type": "string"
+    }
+  }, 
+  "title": "Shadow account and linked VPC account", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.VifAction">VifAction</a> (<a href="#Type.VifAction">type</a>)
+    </h4>
+    <pre>{
+  "id": "VifAction", 
+  "module_id": "VMC", 
+  "properties": {
+    "action": {
+      "enum": [
+        "ATTACH"
+      ], 
+      "required": true, 
+      "title": "Direct Connect VIF (Virtual Interface) action", 
+      "type": "string"
+    }
+  }, 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.VifsListResult">VifsListResult</a> (<a href="#Type.VifsListResult">type</a>)
+    </h4>
+    <pre>{
+  "extends": {
+    "$ref": "<A HREF="#Schema.ListResult">ListResult</A>"<span id="toggle.schema.VifsListResult.3.ListResult" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult" style="display:none">{
+  "abstract": true, 
+  "additionalProperties": false, 
+  "extends": {
+    "$ref": "<A HREF="#Schema.Resource">Resource</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.5.Resource" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.5.Resource" style="display:none">{
+  "abstract": true, 
+  "id": "Resource", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.9.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.5.Resource.Resource.21.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }
+  }, 
+  "title": "Base class for resources", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "ListResult", 
+  "module_id": "Common", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.13.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.13.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.25.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.25.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.3.ListResult.ListResult.25.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Base class for list results from collections", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "VifsListResult", 
+  "module_id": "VMC", 
+  "properties": {
+    "_links": {
+      "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+      "items": {
+        "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.11.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.11.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+      }, 
+      "readonly": true, 
+      "title": "References related to this resource", 
+      "type": "array"
+    }, 
+    "_schema": {
+      "readonly": true, 
+      "title": "Schema for this resource", 
+      "type": "string"
+    }, 
+    "_self": {
+      "$ref": "<A HREF="#Schema.SelfResourceLink">SelfResourceLink</A>"<span id="toggle.schema.VifsListResult.23.SelfResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.23.SelfResourceLink" style="display:none">{
+  "description": "The server will populate this field when returing the resource. Ignored on PUT and POST.", 
+  "extends": {
+    "$ref": "<A HREF="#Schema.ResourceLink">ResourceLink</A>"<span id="toggle.schema.VifsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.23.SelfResourceLink.SelfResourceLink.4.ResourceLink" style="display:none">{
+  "additionalProperties": false, 
+  "id": "ResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "A link to a related resource", 
+  "type": "object"
+}
+</span>
+  }, 
+  "id": "SelfResourceLink", 
+  "module_id": "Common", 
+  "properties": {
+    "action": {
+      "readonly": true, 
+      "title": "Optional action", 
+      "type": "string"
+    }, 
+    "href": {
+      "readonly": true, 
+      "required": true, 
+      "title": "Link to resource", 
+      "type": "string"
+    }, 
+    "rel": {
+      "description": "Custom relation type (follows RFC 5988 where appropriate definitions exist)", 
+      "readonly": true, 
+      "required": true, 
+      "title": "Link relation type", 
+      "type": "string"
+    }
+  }, 
+  "title": "Link to this resource", 
+  "type": "object"
+}
+</span>, 
+      "readonly": true, 
+      "title": "Link to this resource"
+    }, 
+    "cursor": {
+      "readonly": true, 
+      "title": "Opaque cursor to be used for getting next page of records (supplied by current result page)", 
+      "type": "string"
+    }, 
+    "result_count": {
+      "readonly": true, 
+      "title": "Count of results found (across all pages), set only on first page", 
+      "type": "integer"
+    }, 
+    "results": {
+      "items": {
+        "$ref": "<A HREF="#Schema.VirtualInterface">VirtualInterface</A>"<span id="toggle.schema.VifsListResult.39.VirtualInterface" class="schema_toggle" onclick="toggleSchemaExpansion(this)">+</span><span class="expanded_schema" id="expanded.schema.VifsListResult.39.VirtualInterface" style="display:none">{
+  "id": "VirtualInterface", 
+  "module_id": "VMC", 
+  "properties": {
+    "bgp_status": {
+      "enum": [
+        "UP", 
+        "DOWN"
+      ], 
+      "required": true, 
+      "title": "BGP status", 
+      "type": "string"
+    }, 
+    "direct_connect_id": {
+      "required": true, 
+      "title": "Identifier for the Direct Connect", 
+      "type": "string"
+    }, 
+    "id": {
+      "description": "Identifier for the virtual interface", 
+      "required": true, 
+      "title": "VIF (Virtual Interface) identifier", 
+      "type": "string"
+    }, 
+    "name": {
+      "required": true, 
+      "title": "VIF name", 
+      "type": "string"
+    }, 
+    "state": {
+      "enum": [
+        "CONFIRMING", 
+        "VERIFYING", 
+        "PENDING", 
+        "AVAILABLE", 
+        "DOWN", 
+        "DELETING", 
+        "DELETED", 
+        "REJECTED", 
+        "ATTACHED", 
+        "ATTACHING", 
+        "ERROR"
+      ], 
+      "required": true, 
+      "title": "VIF State", 
+      "type": "string"
+    }
+  }, 
+  "type": "object"
+}
+</span>
+      }, 
+      "required": false, 
+      "title": "VIFs list", 
+      "type": "array"
+    }, 
+    "sort_ascending": {
+      "readonly": true, 
+      "title": "If true, results are sorted in ascending order", 
+      "type": "boolean"
+    }, 
+    "sort_by": {
+      "readonly": true, 
+      "title": "Field by which records are sorted", 
+      "type": "string"
+    }
+  }, 
+  "title": "Direct Connect VIFs (Virtual Interface) list query result", 
+  "type": "object"
+}
+</pre>
+
+    <h4>
+      <a name="Schema.VirtualInterface">VirtualInterface</a> (<a href="#Type.VirtualInterface">type</a>)
+    </h4>
+    <pre>{
+  "id": "VirtualInterface", 
+  "module_id": "VMC", 
+  "properties": {
+    "bgp_status": {
+      "enum": [
+        "UP", 
+        "DOWN"
+      ], 
+      "required": true, 
+      "title": "BGP status", 
+      "type": "string"
+    }, 
+    "direct_connect_id": {
+      "required": true, 
+      "title": "Identifier for the Direct Connect", 
+      "type": "string"
+    }, 
+    "id": {
+      "description": "Identifier for the virtual interface", 
+      "required": true, 
+      "title": "VIF (Virtual Interface) identifier", 
+      "type": "string"
+    }, 
+    "name": {
+      "required": true, 
+      "title": "VIF name", 
+      "type": "string"
+    }, 
+    "state": {
+      "enum": [
+        "CONFIRMING", 
+        "VERIFYING", 
+        "PENDING", 
+        "AVAILABLE", 
+        "DOWN", 
+        "DELETING", 
+        "DELETED", 
+        "REJECTED", 
+        "ATTACHED", 
+        "ATTACHING", 
+        "ERROR"
+      ], 
+      "required": true, 
+      "title": "VIF State", 
+      "type": "string"
+    }
+  }, 
+  "type": "object"
+}
+</pre>
+
+
+
+
+<br><br>
+<H2><A name="Errors">API Errors</A></H2>
+
+  
+
+
+    <H4><A name="Errors.301">301 - Moved Permanently</A></H4>
+    <div><p>Request must be reissued to a different controller node.</p>
+<p>The controller node has been replaced by a new node that should be used for this and all future requests.</p>
+</div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>301 Moved Permanently</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain<br>Location: &lt;URI for new request&gt;</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.307">307 - Temporary Redirect</A></H4>
+    <div><p>Request should be reissued to a different controller node.</p>
+<p>The controller node is requesting the client make further requests against the controller node specified in the Location header.  Clients should continue to use the new server until directed otherwise by the new controller node.</p>
+</div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>307 Temporary Redirect</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain<br>Location: &lt;URI for new request&gt;</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.400">400 - Bad Request</A></H4>
+    <div><p>Request was improperly formatted or contained an invalid parameter.</p>
+</div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>400 Bad Request</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.403">403 - Forbidden</A></H4>
+    <div><p>The client does not have sufficient privileges to execute the request.</p>
+<p>The API is likely in read-only mode, or a request was made to modify a read-only property.</p>
+</div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>403 Forbidden</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.404">404 - Not Found</A></H4>
+    <div><p>An entity referenced in the request does not exist.</p>
+<p>Create the referenced resource first, then reissue the request.</p></div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>404 Not Found</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.500">500 - Internal Server Error</A></H4>
+    <div><p>An internal error occurred while executing the request.  If the problem persists, perform diagnostic system tests, or contact your support representative.</p></div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>500 Internal Server Error</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+    <H4><A name="Errors.503">503 - Service Unavailable</A></H4>
+    <div><p>The request can not be performed because the associatedresource could not be reached or is temporarily busy.  Verify theassociated resource is connected, then reissue the request.</p></div>
+    <table class="error_table" border="1">
+      <tbody>
+        <tr>
+          <td class="title-cell">Response Code</td>
+          <td>503 Service Unavailable</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Headers</td>
+          <td>Content-Type: text/plain</td>
+        </tr>
+        <tr>
+          <td class="title-cell">Response Body</td>
+          <td>Additional information about the error, if available.</td>
+        </tr>
+      </tbody>
+    </table>
+
+
+</DIV>
+</BODY>
+</HTML>
+


### PR DESCRIPTION
I was asked to include the HTML documentation for our NSX APIs in the github repo, so added 2 new HTML files, and updated the README.md (which was also missing entries for the existing NSX python API  docs).