### PR TITLE
Add example pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,22 @@ A Python virtual environment is also highly recommended.
 
 ### Installing Required Python Packages
 
+See example below for specifying the --extra-index-url parameter.
+
 ```cmd
 git clone https://github.com/vmware/vsphere-automation-sdk-python.git
 cd vsphere-automation-sdk-python
 pip install --upgrade --force-reinstall -r requirements.txt --extra-index-url file:///<absolute_path_to_sdk>/lib
 ```
+
+Example pip install command on Mac OSX. 
+
+*NOTE*: Be sure to change username "strefethen" to your username:
+
+```cmd
+pip install --upgrade --force-reinstall -r requirements.txt --extra-index-url file:///Users/strefethen/github/vsphere-automation-sdk-python/lib
+```
+
 
 **NOTE:** The SDK also requires OpenSSL 1.0.1+ if you want to connect to vSphere 6.5+ in order to support TLS1.1 & 1.2
 


### PR DESCRIPTION
I've added an example of the pip install command for OSX which illustrates what's expected as the --extra-index-url.