### PR TITLE
Update links for NSX-T API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ $ python samples/vsphere/vcenter/vm/list_vms.py -v
 
 ### NSX API Documentation
 
-* [NSX Policy](https://vmware.github.io/vsphere-automation-sdk-python/nsx/nsx_policy/index.html)
-* [NSX VMC App](https://vmware.github.io/vsphere-automation-sdk-python/nsx/vmc_app/index.html)
+* [NSX Policy](https://vmware.github.io/vsphere-automation-sdk-python/nsx/nsx_policy/index.html) - primary API for managing logical networks
+* [NSX VMC Cloud Service](https://vmware.github.io/vsphere-automation-sdk-python/nsx/vmc_app/index.html) - for managing AWS underlay networks
 
 ## Troubleshooting
 


### PR DESCRIPTION
Make vmc-app link "NSX VMC Cloud Service" and include some
explanatory text for each link.

Signed-Off-By: Gordon Good <ggood@vmware.com>