### PR TITLE
Add a basic sample template for simple samples

### DIFF
--- a/sample_template/README.md
+++ b/sample_template/README.md
@@ -1,10 +1,5 @@
 Boilerplate code for new samples
 ================================
 
-sample_template.py contains boilerplate code that can be used for most of 
-the new samples. Please fill out the TODOs with your sample information.
-The steps included in the template code are:
- 
- * Cmd line argument parser.
- * Login to vAPI services using vSphere Automation API.
- * Cleanup after sample execution.
+* For complex samples require setup and cleanup please use sample_template_complex.py    
+* For simple samples which just demo basic API usage please use sample_template_basic.py

--- a/sample_template/sample_template_basic.py
+++ b/sample_template/sample_template_basic.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""
+* *******************************************************
+* Copyright (c) VMware, Inc. 2019. All Rights Reserved.
+* SPDX-License-Identifier: MIT
+* *******************************************************
+*
+* DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+* EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+* WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+* NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+"""
+
+__author__ = 'TODO: <your name and email>'
+__vcenter_version__ = 'TODO: <compatible vcenter versions>'
+
+from com.vmware.vcenter_client import VM
+from vmware.vapi.vsphere.client import create_vsphere_client
+
+from samples.vsphere.common import sample_cli
+from samples.vsphere.common import sample_util
+from samples.vsphere.common.ssl_helper import get_unverified_session
+
+
+"""
+TODO: Sample description and prerequisites.
+e.g. Demonstrates getting list of VMs present in vCenter
+
+Sample Prerequisites:
+    - vCenter
+"""
+
+# Create argument parser for standard inputs:
+# server, username, password, cleanup and skipverification
+parser = sample_cli.build_arg_parser()
+
+# Add your custom input arguments
+parser.add_argument('--vm_name',
+                    action='store',
+                    default='Sample_Default_VM_for_Simple_Testbed',
+                    help='Name of the testing vm')
+
+args = sample_util.process_cli_args(parser.parse_args())
+
+# Skip server cert verification if needed.
+# This is not recommended in production code.
+session = get_unverified_session() if args.skipverification else None
+
+# Connect to vSphere client
+client = create_vsphere_client(server=args.server,
+                               username=args.username,
+                               password=args.password,
+                               session=session)
+
+# List VMs
+filter_spec = VM.FilterSpec(names=set([args.vm_name]))
+vms = client.vcenter.VM.list(filter_spec)
+print(vms)

--- a/sample_template/sample_template_complex.py
+++ b/sample_template/sample_template_complex.py
@@ -38,7 +38,7 @@ class Sample(object):
         parser = sample_cli.build_arg_parser()
 
         # Add your custom input arguments
-        parser.add_argument('-n', '--vm_name',
+        parser.add_argument('--vm_name',
                             action='store',
                             default='Sample_Default_VM_for_Simple_Testbed',
                             help='Name of the testing vm')


### PR DESCRIPTION
The current sample template treat sample as a class. It work well for complex samples when setup and cleanup are needed and some logic is in place. However it's not needed for basic samples which just demo one or two API usage. The code snippets with self. are also hard to use for users who just want to copy/paste to their script. Creating another template for basic samples.

Other example of such simple samples are: https://github.com/vmware/vsphere-automation-sdk-python/tree/master/samples/vmc/tasks

Signed-off-by: Tianhao He <het@vmware.com>