### PR TITLE
pip install from repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(name='vSphere Automation SDK',
+      version='1.0.0',
+      description='VMware vSphere Automation SDK for Python',
+      url='https://github.com/vmware/vsphere-automation-sdk-python',
+      author='VMware, Inc.',
+      license='MIT',
+      install_requires=[
+        'lxml >= 4.3.0',
+        'suds ; python_version < "3"',
+        'suds-jurko ; python_version >= "3.0"',
+        'pyVmomi >= 6.7',
+        'vapi-runtime @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl',
+        'vapi-client-bindings @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl',
+        'vapi-common-client @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl',
+        'vmc-client-bindings @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl',
+        'nsx-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
+        'nsx-policy-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
+        'nsx-vmc-policy-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
+        'nsx-vmc-aws-integration-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'
+      ]
+      )


### PR DESCRIPTION
As we don't have all dependencies in PyPI, this enables users to install the package directly from repository using `pip`. References the issues #38 and #161. 
It was tested with both Python2 and Python3 on CentOS and Photon containers, Mac OS X and Windows 10. Test results are posted in discussion of #38.

Requires newer version of `setuptools`.

**After** merging it should be possible to install the package with the following commands.
```
pip install --upgrade pip setuptools
pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
```
The line `git+https://github.com/vmware/vsphere-automation-sdk-python.git` could also be added to _requirements.txt_ and installed along with other requirements.

**Notes**
* _setup.py_ should be maintained accordingly, in case the names of the WHL files in lib folder are modified. It might be accomplished by tagging the changes and modifying setup.py accordingly or by removing the versions from names of whls in under ./lib and keep the versioning in using git tags.
* When the dependencies will be in PyPI, this setup.py can be easily modified to install all dependencies from there.
* This setup.py is not 100% PEP8 compatible. Splitting URLs makes the dependencies + urls hard to read and understand. It'll be changed, in case no exception is allowed for setup.py.