### PR TITLE
Optimized setup.py for version control

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 from setuptools import setup
 
 setup(name='vSphere Automation SDK',
@@ -13,13 +15,13 @@ setup(name='vSphere Automation SDK',
         'suds ; python_version < "3"',
         'suds-jurko ; python_version >= "3.0"',
         'pyVmomi >= 6.7',
-        'vapi-runtime @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl',
-        'vapi-client-bindings @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl',
-        'vapi-common-client @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl',
-        'vmc-client-bindings @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl',
-        'nsx-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
-        'nsx-policy-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
-        'nsx-vmc-policy-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl',
-        'nsx-vmc-aws-integration-python-sdk @ https://github.com/vmware/vsphere-automation-sdk-python/raw/master/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'
+        'vapi-runtime @ file://localhost/{}/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl'.format(os.getcwd()),
+        'vapi-client-bindings @ file://localhost/{}/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl'.format(os.getcwd()),
+        'vapi-common-client @ file://localhost/{}/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl'.format(os.getcwd()),
+        'vmc-client-bindings @ file://localhost/{}/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl'.format(os.getcwd()),
+        'nsx-python-sdk @ file://localhost/{}/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'.format(os.getcwd()),
+        'nsx-policy-python-sdk @ file://localhost/{}/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'.format(os.getcwd()),
+        'nsx-vmc-policy-python-sdk @ file://localhost/{}/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'.format(os.getcwd()),
+        'nsx-vmc-aws-integration-python-sdk @ file://localhost/{}/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl'.format(os.getcwd()),
       ]
       )


### PR DESCRIPTION
This PR optimises pip setup by referencing already cloned files instead of downloading them from https git repo.
It also simplifies version management and installation by removing any repository specific information (branch/tag/commit) from setup.py. Each version of repo (tag/branch/commit) can have its own mapping between setup.py and wheel names.

After merging the same installation method should still be used: 
```
pip install --upgrade pip setuptools
pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git`
```

This method was tested across different OS Versions (Linux CentOS/Photon, Mac OS X, Windows). 

Find below the test results:

Notes: 
* With current implementation of PEP 440 in pip/setuptools we still need to `localhost` in path url to have compatibility across platforms.
* It would be good to tag the repository after merging to enable installing consistent version with `pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git@<VERSION TAG>`

# MacOS X (venv)

## Python 2
```
~ $ virtualenv -p python vsphere
~ $ cd vsphere
~ $ source ./bin/activate
~ $ pip install --upgrade pip setuptools
~ $ pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/c6/ad/fe41992c0d3f1a8935f35bcfa6ac3f2d2f022959cf2d52651e3a1b432b11/lxml-4.3.4-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds (from vSphere-Automation-SDK==1.0.0)
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in ./lib/python2.7/site-packages (from vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e2/bf/3b641820c561aedde134e88528ba68dffe41ed238899fab7f7ef20118aaf/cryptography-2.7-cp27-cp27m-macosx_10_6_intel.whl
Collecting enum34; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/16/f6/46a3dece43541b2cbf3776ec2299e370a2408d9380958401cacb6d101853/cffi-1.12.3-cp27-cp27m-macosx_10_6_intel.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting ipaddress; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/fc/d0/7fc3a811e011d4b388be48a0e381db8d990042df54aa4ef4599a31d39853/ipaddress-1.0.22-py2.py3-none-any.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-CLYtqd/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
Building wheels for collected packages: vSphere-Automation-SDK
  Building wheel for vSphere-Automation-SDK (setup.py) ... done
  Stored in directory: /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-ephem-wheel-cache-elKyQl/wheels/1d/b2/fc/850fa96afab399d92e0b370cc4cb104dcc3ac19272219ee778
Successfully built vSphere-Automation-SDK
Installing collected packages: lxml, urllib3, certifi, chardet, idna, requests, six, pyVmomi, enum34, pycparser, cffi, asn1crypto, ipaddress, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds, vSphere-Automation-SDK
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 enum34-1.1.6 idna-2.8 ipaddress-1.0.22 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-0.4 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```

## Python 3
```
~ $ virtualenv -p python3 vsphere
~ $ cd vsphere
~ $ source ./bin/activate
~ $ pip install --upgrade pip setuptools
~ $ pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/1d/16/c220beb03c4b4609924f0fc1bee5e0e5e8082089103fdc0b2a7c8b8bb003/lxml-4.3.4-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing //private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds-jurko (from vSphere-Automation-SDK==1.0.0)
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in ./lib/python3.7/site-packages (from vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/63/4e/57b7a6bd98906872fcd2531e74b532de2abe17d675a5cf171931fcb4a9e8/cryptography-2.7-cp34-abi3-macosx_10_6_intel.whl
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/f0/48/5aa4ea664eba26dd5142558d04762f5065c02220b4665b3f7eecb9bb614e/cffi-1.12.3-cp37-cp37m-macosx_10_9_x86_64.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-req-build-9xig1vam/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
Building wheels for collected packages: vSphere-Automation-SDK
  Building wheel for vSphere-Automation-SDK (setup.py) ... done
  Stored in directory: /private/var/folders/q5/8gx0gtcx2jb7fqmb3c310knc0000gn/T/pip-ephem-wheel-cache-jpu5dtoe/wheels/1d/b2/fc/850fa96afab399d92e0b370cc4cb104dcc3ac19272219ee778
Successfully built vSphere-Automation-SDK
Installing collected packages: lxml, six, idna, certifi, urllib3, chardet, requests, pyVmomi, pycparser, cffi, asn1crypto, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds-jurko, vSphere-Automation-SDK
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 idna-2.8 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-jurko-0.6 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```


# CentOS 7

## Python2

```
docker run -it centos /bin/bash

[root@2416f67c84fa /]# yum install -y epel-release

[root@2416f67c84fa /]# yum install -y python27 python2-pip git
[root@2416f67c84fa /]# pip install --upgrade pip setuptools

[root@2416f67c84fa /]# pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /tmp/pip-req-build-BgC_Hm
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /tmp/pip-req-build-BgC_Hm
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch fix-setup_req_file set up to track remote branch fix-setup_req_file from origin.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/af/31/47cce58942bbf4b8f1c975ec2d1ab52141f7b7cf8cdecb58f25546d2c4fd/lxml-4.3.4-cp27-cp27mu-manylinux1_x86_64.whl (5.6MB)
     |################################| 5.6MB 2.9MB/s
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip (632kB)
     |################################| 634kB 11.1MB/s
Processing ./tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-BgC_Hm/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/d6/960acce47ee6f096345fe5a7d9be7708135fd1d0713571836f073efc7393/suds-0.4.tar.gz (104kB)
     |################################| 112kB 4.4MB/s
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)
     |################################| 61kB 12.9MB/s
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl (53kB)
     |################################| 61kB 15.3MB/s
Requirement already satisfied: setuptools in /usr/lib/python2.7/site-packages (from vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
     |################################| 143kB 15.1MB/s
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)
     |################################| 61kB 13.7MB/s
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl (150kB)
     |################################| 153kB 11.5MB/s
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl (157kB)
     |################################| 163kB 13.0MB/s
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/68/50698ce24c61db7d44d93a5043c621a0ca7839d4ef9dff913e6ab465fc92/cryptography-2.7-cp27-cp27mu-manylinux1_x86_64.whl (2.3MB)
     |################################| 2.3MB 10.5MB/s
Collecting enum34; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
     |################################| 102kB 10.2MB/s
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/8d/e9/0c8afd1579e5cf7bc0f06fbcd7cdb954cbc0baadd505973949a99337da1c/cffi-1.12.3-cp27-cp27mu-manylinux1_x86_64.whl (415kB)
     |################################| 419kB 9.9MB/s
Requirement already satisfied: ipaddress; python_version < "3" in /usr/lib/python2.7/site-packages (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (1.0.16)
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-BgC_Hm/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz (158kB)
     |################################| 163kB 13.0MB/s
Installing collected packages: lxml, chardet, idna, urllib3, certifi, requests, six, pyVmomi, enum34, asn1crypto, pycparser, cffi, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds, vSphere-Automation-SDK
  Found existing installation: chardet 2.2.1
    Uninstalling chardet-2.2.1:
      Successfully uninstalled chardet-2.2.1
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  Running setup.py install for suds ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 enum34-1.1.6 idna-2.8 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-0.4 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```

## Python3

```
[root@2416f67c84fa /]# docker run -it centos /bin/bash

[root@2416f67c84fa /]# yum install -y epel-release

[root@2416f67c84fa /]# yum install -y python36 python36-pip git
[root@2416f67c84fa /]# pip3 install --upgrade pip setuptools
[root@2416f67c84fa /]# hash -d pip3
[root@2416f67c84fa /]# pip3 install install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
[root@cc255c92708e /]# pip3 install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /tmp/pip-req-build-eavnm0li
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /tmp/pip-req-build-eavnm0li
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch fix-setup_req_file set up to track remote branch fix-setup_req_file from origin.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/2d/53/34a9f0c79c548e430148837892b6ae91adee571a0e8b6c17bd7ff9c2d12e/lxml-4.3.4-cp36-cp36m-manylinux1_x86_64.whl (5.7MB)
     |################################| 5.7MB 2.1MB/s
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip (632kB)
     |################################| 634kB 23.7MB/s
Processing ./tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-eavnm0li/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds-jurko (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bd/6f/54fbf0999a606680d27c69b1ad12dfff62768ecb9fe48524cebda6eb4423/suds-jurko-0.6.tar.bz2 (143kB)
     |################################| 153kB 7.9MB/s
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)
     |################################| 61kB 9.6MB/s
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in /usr/local/lib/python3.6/site-packages (from vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl (53kB)
     |################################| 61kB 11.4MB/s
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl (157kB)
     |################################| 163kB 8.9MB/s
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)
     |################################| 61kB 10.3MB/s
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
     |################################| 143kB 12.4MB/s
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl (150kB)
     |################################| 153kB 9.3MB/s
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/97/18/c6557f63a6abde34707196fb2cad1c6dc0dbff25a200d5044922496668a4/cryptography-2.7-cp34-abi3-manylinux1_x86_64.whl (2.3MB)
     |################################| 2.3MB 13.5MB/s
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/5f/bf/6aa1925384c23ffeb579e97a5569eb9abce41b6310b329352b8252cee1c3/cffi-1.12.3-cp36-cp36m-manylinux1_x86_64.whl (430kB)
     |################################| 440kB 10.3MB/s
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
     |################################| 102kB 11.5MB/s
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-eavnm0li/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz (158kB)
     |################################| 163kB 10.1MB/s
Installing collected packages: lxml, certifi, idna, chardet, urllib3, requests, six, pyVmomi, pycparser, cffi, asn1crypto, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds-jurko, vSphere-Automation-SDK
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  Running setup.py install for suds-jurko ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 idna-2.8 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-jurko-0.6 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```


# Photon

## Python2
```
~ $ docker run -it --rm photon
Unable to find image 'photon:latest' locally
latest: Pulling from library/photon
4f1c521c164a: Pull complete
Digest: sha256:1a09eb82691ac8e5302602cf9e636f5478a45357a85fc81c685341c50891c5df
Status: Downloaded newer image for photon:latest

root [ / ]# tdnf -qy install python-setuptools python-pip git
using empty dict to provide pw_dict
root [ / ]#
root [ / ]# pip install --upgrade pip setuptools
Collecting pip
  Downloading https://files.pythonhosted.org/packages/5c/e0/be401c003291b56efc55aeba6a80ab790d3d4cece2778288d65323009420/pip-19.1.1-py2.py3-none-any.whl (1.4MB)
    100% |################################| 1.4MB 6.7MB/s
Collecting setuptools
  Downloading https://files.pythonhosted.org/packages/ec/51/f45cea425fd5cb0b0380f5b0f048ebc1da5b417e48d304838c02d6288a1e/setuptools-41.0.1-py2.py3-none-any.whl (575kB)
    100% |################################| 583kB 12.5MB/s
Installing collected packages: pip, setuptools
  Found existing installation: pip 18.0
    Uninstalling pip-18.0:
      Successfully uninstalled pip-18.0
  Found existing installation: setuptools 40.2.0
    Uninstalling setuptools-40.2.0:
      Successfully uninstalled setuptools-40.2.0
Successfully installed pip-19.1.1 setuptools-41.0.1

root [ / ]# pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /tmp/pip-req-build-96kXgl
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /tmp/pip-req-build-96kXgl
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/af/31/47cce58942bbf4b8f1c975ec2d1ab52141f7b7cf8cdecb58f25546d2c4fd/lxml-4.3.4-cp27-cp27mu-manylinux1_x86_64.whl (5.6MB)
     |################################| 5.6MB 2.8MB/s
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip (632kB)
     |################################| 634kB 19.1MB/s
Processing ./tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-96kXgl/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/d6/960acce47ee6f096345fe5a7d9be7708135fd1d0713571836f073efc7393/suds-0.4.tar.gz (104kB)
     |################################| 112kB 17.9MB/s
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)
     |################################| 61kB 12.3MB/s
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl (53kB)
     |################################| 61kB 8.7MB/s
Requirement already satisfied: setuptools in /usr/lib/python2.7/site-packages (from vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
     |################################| 143kB 10.8MB/s
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)
     |################################| 61kB 10.1MB/s
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl (150kB)
     |################################| 153kB 11.4MB/s
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl (157kB)
     |################################| 163kB 7.2MB/s
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/68/50698ce24c61db7d44d93a5043c621a0ca7839d4ef9dff913e6ab465fc92/cryptography-2.7-cp27-cp27mu-manylinux1_x86_64.whl (2.3MB)
     |################################| 2.3MB 13.2MB/s
Collecting enum34; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
     |################################| 102kB 6.6MB/s
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/8d/e9/0c8afd1579e5cf7bc0f06fbcd7cdb954cbc0baadd505973949a99337da1c/cffi-1.12.3-cp27-cp27mu-manylinux1_x86_64.whl (415kB)
     |################################| 419kB 12.5MB/s
Collecting ipaddress; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/fc/d0/7fc3a811e011d4b388be48a0e381db8d990042df54aa4ef4599a31d39853/ipaddress-1.0.22-py2.py3-none-any.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-96kXgl/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz (158kB)
     |################################| 163kB 14.3MB/s
Installing collected packages: lxml, chardet, idna, urllib3, certifi, requests, six, pyVmomi, enum34, asn1crypto, pycparser, cffi, ipaddress, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds, vSphere-Automation-SDK
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  Running setup.py install for suds ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 enum34-1.1.6 idna-2.8 ipaddress-1.0.22 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-0.4 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```

## Python3
```
root [ / ]# tdnf -qy install python3-pip python3-setuptools git

root [ / ]# pip install --upgrade pip setuptools
root [ / ]# pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to /tmp/pip-req-build-hhsl1llv
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git /tmp/pip-req-build-hhsl1llv
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Switched to a new branch 'fix-setup_req_file'
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ef/7a/a42b825b27eaa0deedec913e797dd3e4bef51f21d5f0027a87562342fd25/lxml-4.3.4-cp37-cp37m-manylinux1_x86_64.whl
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip
Processing ./tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/vapi-client-bindings/vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/vapi-common-client/vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/vmc-client-bindings/vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/nsx-python-sdk/nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/nsx-policy-python-sdk/nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/nsx-vmc-policy-python-sdk/nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing ./tmp/pip-req-build-hhsl1llv/lib/nsx-vmc-aws-integration-python-sdk/nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds-jurko (from vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bd/6f/54fbf0999a606680d27c69b1ad12dfff62768ecb9fe48524cebda6eb4423/suds-jurko-0.6.tar.bz2 (143kB)
     |████████████████████████████████| 153kB 3.1MB/s
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)
     |████████████████████████████████| 61kB 9.5MB/s
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in /usr/lib/python3.7/site-packages (from vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (40.8.0)
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl (53kB)
     |████████████████████████████████| 61kB 6.4MB/s
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
     |████████████████████████████████| 143kB 8.8MB/s
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl (150kB)
     |████████████████████████████████| 153kB 7.4MB/s
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl (157kB)
     |████████████████████████████████| 163kB 9.9MB/s
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)
     |████████████████████████████████| 61kB 8.9MB/s
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/97/18/c6557f63a6abde34707196fb2cad1c6dc0dbff25a200d5044922496668a4/cryptography-2.7-cp34-abi3-manylinux1_x86_64.whl (2.3MB)
     |████████████████████████████████| 2.3MB 11.1MB/s
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/a0/ea/37fe21475c884f88a2ae496cab10e8f84f0cc11137be860af9eb37a3edb9/cffi-1.12.3-cp37-cp37m-manylinux1_x86_64.whl (430kB)
     |████████████████████████████████| 440kB 8.4MB/s
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl (101kB)
     |████████████████████████████████| 102kB 11.1MB/s
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost//tmp/pip-req-build-hhsl1llv/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Downloading https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz (158kB)
     |████████████████████████████████| 163kB 8.4MB/s
Installing collected packages: lxml, chardet, urllib3, certifi, idna, requests, six, pyVmomi, pycparser, cffi, asn1crypto, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds-jurko, vSphere-Automation-SDK
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  Running setup.py install for suds-jurko ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 idna-2.8 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-jurko-0.6 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```

# Windows 10

## Python2 (2.7.16)
```
C:\Users\Khachatur Nazaretyan\AppData\Local\Programs\Python\Python27>Scripts\pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git 'c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh'
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
  Switched to a new branch 'fix-setup_req_file'
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ef/e2/1968eb678147ef6bb6ef780d317f6eb25ea87bd427bcce1098c251f5461f/lxml-4.3.4-cp27-cp27m-win_amd64.whl
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\vapi-runtime\vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\vapi-client-bindings\vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\vapi-common-client\vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\vmc-client-bindings\vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\nsx-python-sdk\nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\nsx-policy-python-sdk\nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\nsx-vmc-policy-python-sdk\nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh\lib\nsx-vmc-aws-integration-python-sdk\nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/d6/960acce47ee6f096345fe5a7d9be7708135fd1d0713571836f073efc7393/suds-0.4.tar.gz
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in c:\users\khachatur nazaretyan\appdata\roaming\python\python27\site-packages (from vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/d8/30/6313af106e5abff8bfa78eb2ce630673bb5add4fafd3b28d4bd0271c8e7f/cryptography-2.7-cp27-cp27m-win_amd64.whl
Collecting enum34; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting ipaddress; python_version < "3" (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/fc/d0/7fc3a811e011d4b388be48a0e381db8d990042df54aa4ef4599a31d39853/ipaddress-1.0.22-py2.py3-none-any.whl
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/fa/24/37ec704b98ffc36e7d0ade9e4653539c0b8e6fec34f084f30194609aa10b/cffi-1.12.3-cp27-cp27m-win_amd64.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/c:\users\khacha~1\appdata\local\temp\pip-req-build-yt0djh/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz
Installing collected packages: lxml, certifi, urllib3, idna, chardet, requests, six, pyVmomi, enum34, asn1crypto, ipaddress, pycparser, cffi, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds, vSphere-Automation-SDK
  WARNING: The script chardetect.exe is installed in 'c:\users\khachatur nazaretyan\appdata\local\programs\python\python27\Scripts' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  WARNING: The script vapi-server.exe is installed in 'c:\users\khachatur nazaretyan\appdata\local\programs\python\python27\Scripts' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  Running setup.py install for suds ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 enum34-1.1.6 idna-2.8 ipaddress-1.0.22 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-0.4 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```

## Python3 (3.7.3)

```
C:\Users\Khachatur Nazaretyan\AppData\Local\Programs\Python\Python37>Scripts\pip install git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
Collecting git+https://github.com/khnazaretyan/vsphere-automation-sdk-python.git@fix-setup_req_file
  Cloning https://github.com/khnazaretyan/vsphere-automation-sdk-python.git (to revision fix-setup_req_file) to c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt
  Running command git clone -q https://github.com/khnazaretyan/vsphere-automation-sdk-python.git 'C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt'
  Running command git checkout -b fix-setup_req_file --track origin/fix-setup_req_file
  Branch 'fix-setup_req_file' set up to track remote branch 'fix-setup_req_file' from 'origin'.
  Switched to a new branch 'fix-setup_req_file'
Collecting lxml>=4.3.0 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/c6/22/a43126b87020c325fac159bb3b7f4e7ea99e7b2594ce5b8fa23cfa6ee90d/lxml-4.3.4-cp37-cp37m-win_amd64.whl
Collecting pyVmomi>=6.7 (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/71/24/0bb1257b3bc89f7b2facdbad91cc56902d116d649a263c242ef32f73110e/pyvmomi-6.7.1.2018.12.zip
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\vapi-runtime\vapi_runtime-2.12.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\vapi-client-bindings\vapi_client_bindings-3.0.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\vapi-common-client\vapi_common_client-2.12.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\vmc-client-bindings\vmc_client_bindings-1.6.0-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\nsx-python-sdk\nsx_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\nsx-policy-python-sdk\nsx_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\nsx-vmc-policy-python-sdk\nsx_vmc_policy_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Processing c:\users\khacha~1\appdata\local\temp\pip-req-build-em67x1pt\lib\nsx-vmc-aws-integration-python-sdk\nsx_vmc_aws_integration_python_sdk-2.3.0.0.3.13851140-py2.py3-none-any.whl
Collecting suds-jurko (from vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bd/6f/54fbf0999a606680d27c69b1ad12dfff62768ecb9fe48524cebda6eb4423/suds-jurko-0.6.tar.bz2
Collecting requests>=2.3.0 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Collecting six>=1.7.3 (from pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in c:\users\khachatur nazaretyan\appdata\roaming\python\python37\site-packages (from vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0) (41.0.1)
Collecting pyOpenSSL>=18.0.0 (from vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e6/60/247f23a7121ae632d62811ba7f273d0e58972d75e58a94d329d51550a47d/urllib3-1.25.3-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting idna<2.9,>=2.5 (from requests>=2.3.0->pyVmomi>=6.7->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
Collecting cryptography>=2.3 (from pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/33/73/fc8c85104bd316086a7717d4970aec5e05fafcd6b9bf7257fe3621b180a0/cryptography-2.7-cp37-cp37m-win_amd64.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting cffi!=1.11.3,>=1.8 (from cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/2f/ad/9722b7752fdd88c858be57b47f41d1049b5fb0ab79caf0ab11407945c1a7/cffi-1.12.3-cp37-cp37m-win_amd64.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography>=2.3->pyOpenSSL>=18.0.0->vapi-runtime@ file://localhost/C:\Users\KHACHA~1\AppData\Local\Temp\pip-req-build-em67x1pt/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl->vSphere-Automation-SDK==1.0.0)
  Using cached https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz
Installing collected packages: lxml, certifi, urllib3, chardet, idna, requests, six, pyVmomi, asn1crypto, pycparser, cffi, cryptography, pyOpenSSL, vapi-runtime, vapi-client-bindings, vapi-common-client, vmc-client-bindings, nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-policy-python-sdk, nsx-vmc-aws-integration-python-sdk, suds-jurko, vSphere-Automation-SDK
  WARNING: The script chardetect.exe is installed in 'c:\users\khachatur nazaretyan\appdata\local\programs\python\python37\Scripts' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  Running setup.py install for pyVmomi ... done
  Running setup.py install for pycparser ... done
  WARNING: The script vapi-server.exe is installed in 'c:\users\khachatur nazaretyan\appdata\local\programs\python\python37\Scripts' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  Running setup.py install for suds-jurko ... done
  Running setup.py install for vSphere-Automation-SDK ... done
Successfully installed asn1crypto-0.24.0 certifi-2019.6.16 cffi-1.12.3 chardet-3.0.4 cryptography-2.7 idna-2.8 lxml-4.3.4 nsx-policy-python-sdk-2.3.0.0.3.13851140 nsx-python-sdk-2.3.0.0.3.13851140 nsx-vmc-aws-integration-python-sdk-2.3.0.0.3.13851140 nsx-vmc-policy-python-sdk-2.3.0.0.3.13851140 pyOpenSSL-19.0.0 pyVmomi-6.7.1.2018.12 pycparser-2.19 requests-2.22.0 six-1.12.0 suds-jurko-0.6 urllib3-1.25.3 vSphere-Automation-SDK-1.0.0 vapi-client-bindings-3.0.0 vapi-common-client-2.12.0 vapi-runtime-2.12.0 vmc-client-bindings-1.6.0
```
