### PR TITLE
differentiating required and optional arguments in the help text for …

### DIFF
--- a/samples/vmc/helpers/sample_cli.py
+++ b/samples/vmc/helpers/sample_cli.py
@@ -30,7 +30,7 @@ required_args = parser.add_argument_group(
         'required arguments')
 optional_args = parser.add_argument_group(
         'optional arguments')
-    
+
 required_args.add_argument(
         '--refresh_token',
         required=True,

--- a/samples/vmc/helpers/sample_cli.py
+++ b/samples/vmc/helpers/sample_cli.py
@@ -27,8 +27,7 @@ If any of these arguments are not required, then build your own parser
 --sddc_id
 
 """
-parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+parser = argparse.ArgumentParser()
 
 required_args = parser.add_argument_group(
         'required arguments')

--- a/samples/vmc/helpers/sample_cli.py
+++ b/samples/vmc/helpers/sample_cli.py
@@ -1,0 +1,37 @@
+"""
+* *******************************************************
+* Copyright (c) VMware, Inc. 2019. All Rights Reserved.
+* SPDX-License-Identifier: MIT
+* *******************************************************
+*
+* DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+* EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+* WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+* NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+"""
+
+__author__ = 'VMware, Inc.'
+__copyright__ = 'Copyright 2019 VMware, Inc. All rights reserved.'
+
+import argparse
+
+"""
+Builds a standard argument parser with required and optional argument
+groups
+
+--refresh_token
+
+"""
+parser = argparse.ArgumentParser(
+        description='Standard Arguments for talking to vCenter')
+
+required_args = parser.add_argument_group(
+        'required arguments')
+optional_args = parser.add_argument_group(
+        'optional arguments')
+    
+required_args.add_argument(
+        '--refresh_token',
+        required=True,
+        help='Refresh token obtained from CSP')

--- a/samples/vmc/helpers/sample_cli.py
+++ b/samples/vmc/helpers/sample_cli.py
@@ -17,10 +17,14 @@ __copyright__ = 'Copyright 2019 VMware, Inc. All rights reserved.'
 import argparse
 
 """
-Builds a standard argument parser with required and optional argument
-groups
+Builds a standard argument parser with required and optional argument groups
+
+Most of the VMC samples require these three standard required arguments.
+If any of these arguments are not required, then build your own parser
 
 --refresh_token
+--org_id
+--sddc_id
 
 """
 parser = argparse.ArgumentParser(
@@ -35,3 +39,11 @@ required_args.add_argument(
         '--refresh_token',
         required=True,
         help='Refresh token obtained from CSP')
+required_args.add_argument(
+        '--org_id',
+        required=True,
+        help='Orgization ID')
+required_args.add_argument(
+        '--sddc_id',
+        required=True,
+        help='SDDC ID')

--- a/samples/vmc/networks_nsxt/cgw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/cgw_firewall_crud.py
@@ -17,7 +17,7 @@ __author__ = 'VMware, Inc.'
 __vcenter_version__ = '6.8.0+'
 
 import requests
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import IPAddressExpression
 from com.vmware.nsx_policy.model_client import Group

--- a/samples/vmc/networks_nsxt/cgw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/cgw_firewall_crud.py
@@ -16,8 +16,8 @@
 __author__ = 'VMware, Inc.'
 __vcenter_version__ = '6.8.0+'
 
-import argparse
 import requests
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import IPAddressExpression
 from com.vmware.nsx_policy.model_client import Group
@@ -36,16 +36,6 @@ class NSXPolicyCGWFirewall(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-
-        required_args.add_argument('--refresh_token',
-                            required=True,
-                            help='Refresh token obtained from CSP')
-
         required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')

--- a/samples/vmc/networks_nsxt/cgw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/cgw_firewall_crud.py
@@ -39,7 +39,8 @@ class NSXPolicyCGWFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
 
         required_args.add_argument('--refresh_token',
                             required=True,

--- a/samples/vmc/networks_nsxt/cgw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/cgw_firewall_crud.py
@@ -36,14 +36,6 @@ class NSXPolicyCGWFirewall(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org_id',
-                            required=True,
-                            help='Orgization ID')
-
-        required_args.add_argument('--sddc_id',
-                            required=True,
-                            help='SDDC ID')
-
         args = parser.parse_args()
 
         self.nsx_client = create_nsx_policy_client_for_vmc(

--- a/samples/vmc/networks_nsxt/cgw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/cgw_firewall_crud.py
@@ -39,17 +39,19 @@ class NSXPolicyCGWFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('--refresh_token',
+        required_args = parser.add_argument_group('required arguments')
+
+        required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')
 
-        parser.add_argument('--org_id',
+        required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')
 
-        parser.add_argument('--sddc_id',
+        required_args.add_argument('--sddc_id',
                             required=True,
-                            help='Sddc ID')
+                            help='SDDC ID')
 
         args = parser.parse_args()
 

--- a/samples/vmc/networks_nsxt/dfw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/dfw_firewall_crud.py
@@ -17,7 +17,7 @@ __author__ = 'VMware, Inc.'
 __vcenter_version__ = '6.8.0+'
 
 import requests
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import IPAddressExpression
 from com.vmware.nsx_policy.model_client import Group

--- a/samples/vmc/networks_nsxt/dfw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/dfw_firewall_crud.py
@@ -38,14 +38,6 @@ class NSXPolicyDFWFirewall(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org_id',
-                            required=True,
-                            help='Orgization ID')
-
-        required_args.add_argument('--sddc_id',
-                            required=True,
-                            help='SDDC ID')
-
         args = parser.parse_args()
 
         self.nsx_client = create_nsx_policy_client_for_vmc(

--- a/samples/vmc/networks_nsxt/dfw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/dfw_firewall_crud.py
@@ -41,7 +41,8 @@ class NSXPolicyDFWFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
 
         required_args.add_argument('--refresh_token',
                             required=True,

--- a/samples/vmc/networks_nsxt/dfw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/dfw_firewall_crud.py
@@ -16,8 +16,8 @@
 __author__ = 'VMware, Inc.'
 __vcenter_version__ = '6.8.0+'
 
-import argparse
 import requests
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import IPAddressExpression
 from com.vmware.nsx_policy.model_client import Group
@@ -38,16 +38,6 @@ class NSXPolicyDFWFirewall(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-
-        required_args.add_argument('--refresh_token',
-                            required=True,
-                            help='Refresh token obtained from CSP')
-
         required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')

--- a/samples/vmc/networks_nsxt/dfw_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/dfw_firewall_crud.py
@@ -41,17 +41,19 @@ class NSXPolicyDFWFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('--refresh_token',
+        required_args = parser.add_argument_group('required arguments')
+
+        required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')
 
-        parser.add_argument('--org_id',
+        required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')
 
-        parser.add_argument('--sddc_id',
+        required_args.add_argument('--sddc_id',
                             required=True,
-                            help='Sddc ID')
+                            help='SDDC ID')
 
         args = parser.parse_args()
 

--- a/samples/vmc/networks_nsxt/hello_world.py
+++ b/samples/vmc/networks_nsxt/hello_world.py
@@ -35,17 +35,19 @@ class AuthExample(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument('-r', '--refresh-token',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('-r', '--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')
 
-        parser.add_argument('-o', '--org-id',
+        required_args.add_argument('-o', '--org-id',
                             required=True,
                             help='Organization identifier.')
 
-        parser.add_argument('-s', '--sddc-id',
+        required_args.add_argument('-s', '--sddc-id',
                             required=True,
-                            help='Sddc Identifier.')
+                            help='SDDC Identifier.')
 
         args = parser.parse_args()
 

--- a/samples/vmc/networks_nsxt/hello_world.py
+++ b/samples/vmc/networks_nsxt/hello_world.py
@@ -15,9 +15,8 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
 import pprint
-
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import (
     create_nsx_policy_client_for_vmc)
 
@@ -33,20 +32,11 @@ class AuthExample(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('-r', '--refresh-token',
-                            required=True,
-                            help='VMware Cloud API refresh token')
-
-        required_args.add_argument('-o', '--org-id',
+        required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
 
-        required_args.add_argument('-s', '--sddc-id',
+        required_args.add_argument('--sddc-id',
                             required=True,
                             help='SDDC Identifier.')
 

--- a/samples/vmc/networks_nsxt/hello_world.py
+++ b/samples/vmc/networks_nsxt/hello_world.py
@@ -36,7 +36,8 @@ class AuthExample(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('-r', '--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')

--- a/samples/vmc/networks_nsxt/hello_world.py
+++ b/samples/vmc/networks_nsxt/hello_world.py
@@ -32,14 +32,6 @@ class AuthExample(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org-id',
-                            required=True,
-                            help='Organization identifier.')
-
-        required_args.add_argument('--sddc-id',
-                            required=True,
-                            help='SDDC Identifier.')
-
         args = parser.parse_args()
 
         self.org_id = args.org_id

--- a/samples/vmc/networks_nsxt/hello_world.py
+++ b/samples/vmc/networks_nsxt/hello_world.py
@@ -16,7 +16,7 @@
 __author__ = 'VMware, Inc.'
 
 import pprint
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from com.vmware.nsx_policy_client_for_vmc import (
     create_nsx_policy_client_for_vmc)
 

--- a/samples/vmc/networks_nsxt/l3_vpn_crud.py
+++ b/samples/vmc/networks_nsxt/l3_vpn_crud.py
@@ -42,23 +42,24 @@ class NSXPolicyL3VPN(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('--refresh_token',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')
 
-        parser.add_argument('--org_id',
+        required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')
 
-        parser.add_argument('--sddc_id',
+        required_args.add_argument('--sddc_id',
                             required=True,
-                            help='Sddc ID')
+                            help='SDDC ID')
 
-        parser.add_argument('--remote_endpoint_public_ip',
+        required_args.add_argument('--remote_endpoint_public_ip',
                             required=True,
                             help='L3 VPN Remote end point\'s public ip')
 
-        parser.add_argument('--passphrase',
+        required_args.add_argument('--passphrase',
                             required=True,
                             help='Passphrase used for VPN')
 

--- a/samples/vmc/networks_nsxt/l3_vpn_crud.py
+++ b/samples/vmc/networks_nsxt/l3_vpn_crud.py
@@ -15,7 +15,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from vmware.vapi.bindings.struct import PrettyPrinter as NsxPrettyPrinter
 from com.vmware.nsx_policy.model_client import ApiError
@@ -39,11 +39,6 @@ class NSXPolicyL3VPN(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
         required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/l3_vpn_crud.py
+++ b/samples/vmc/networks_nsxt/l3_vpn_crud.py
@@ -39,18 +39,6 @@ class NSXPolicyL3VPN(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--refresh_token',
-                            required=True,
-                            help='Refresh token obtained from CSP')
-
-        required_args.add_argument('--org_id',
-                            required=True,
-                            help='Orgization ID')
-
-        required_args.add_argument('--sddc_id',
-                            required=True,
-                            help='SDDC ID')
-
         required_args.add_argument('--remote_endpoint_public_ip',
                             required=True,
                             help='L3 VPN Remote end point\'s public ip')

--- a/samples/vmc/networks_nsxt/l3_vpn_crud.py
+++ b/samples/vmc/networks_nsxt/l3_vpn_crud.py
@@ -42,7 +42,8 @@ class NSXPolicyL3VPN(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/nat_crud.py
+++ b/samples/vmc/networks_nsxt/nat_crud.py
@@ -37,14 +37,6 @@ class NSXPolicyNAT(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org_id',
-                            required=True,
-                            help='Orgization ID')
-
-        required_args.add_argument('--sddc_id',
-                            required=True,
-                            help='SDDC ID')
-
         args = parser.parse_args()
 
         self.nsx_client = create_nsx_policy_client_for_vmc(

--- a/samples/vmc/networks_nsxt/nat_crud.py
+++ b/samples/vmc/networks_nsxt/nat_crud.py
@@ -39,17 +39,18 @@ class NSXPolicyNAT(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('--refresh_token',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')
 
-        parser.add_argument('--org_id',
+        required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')
 
-        parser.add_argument('--sddc_id',
+        required_args.add_argument('--sddc_id',
                             required=True,
-                            help='Sddc ID')
+                            help='SDDC ID')
 
         args = parser.parse_args()
 

--- a/samples/vmc/networks_nsxt/nat_crud.py
+++ b/samples/vmc/networks_nsxt/nat_crud.py
@@ -16,8 +16,9 @@
 __author__ = 'VMware, Inc.'
 __vcenter_version__ = '6.8.1+'
 
-import argparse
 import requests
+
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_vmc_app_client_for_vmc import create_nsx_vmc_app_client_for_vmc
 from com.vmware.nsx_vmc_app.model_client import PublicIp
@@ -36,15 +37,6 @@ class NSXPolicyNAT(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('--refresh_token',
-                            required=True,
-                            help='Refresh token obtained from CSP')
-
         required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')

--- a/samples/vmc/networks_nsxt/nat_crud.py
+++ b/samples/vmc/networks_nsxt/nat_crud.py
@@ -18,7 +18,7 @@ __vcenter_version__ = '6.8.1+'
 
 import requests
 
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_vmc_app_client_for_vmc import create_nsx_vmc_app_client_for_vmc
 from com.vmware.nsx_vmc_app.model_client import PublicIp

--- a/samples/vmc/networks_nsxt/nat_crud.py
+++ b/samples/vmc/networks_nsxt/nat_crud.py
@@ -39,7 +39,8 @@ class NSXPolicyNAT(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/security_group_create.py
+++ b/samples/vmc/networks_nsxt/security_group_create.py
@@ -38,7 +38,8 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-required_args = parser.add_argument_group('required arguments')
+required_args = parser.add_argument_group(
+    'required arguments')
 required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/security_group_create.py
+++ b/samples/vmc/networks_nsxt/security_group_create.py
@@ -15,10 +15,11 @@
 __author__ = 'VMware, Inc'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
-import argparse
 import random
 
 import requests
+
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy.model_client import (Expression, Group,
                                                 IPAddressExpression)
@@ -35,24 +36,15 @@ Create a new NSX-T Group on MGW or CGW
 Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
 """
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-required_args = parser.add_argument_group(
-    'required arguments')
-required_args.add_argument('--refresh_token',
-                    required=True,
-                    help='Refresh token obtained from CSP')
-
 required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
 
 required_args.add_argument('--sddc_id',
                     required=True,
-                    help='Sddc ID')
+                    help='SDDC ID')
 
-parser.add_argument('--gateway_type',
+optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')
 
@@ -60,11 +52,11 @@ required_args.add_argument('--name',
                     required=True,
                     help='Name of the security group to be created')
 
-parser.add_argument('--ip_address',
+optional_args.add_argument('--ip_address',
                     default='172.31.0.0/24',
                     help='IP address for the expression')
 
-parser.add_argument('--group_id',
+optional_args.add_argument('--group_id',
                     help='ID of the group. A random ID will be used by default')
 
 args = parser.parse_args()

--- a/samples/vmc/networks_nsxt/security_group_create.py
+++ b/samples/vmc/networks_nsxt/security_group_create.py
@@ -38,15 +38,16 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument('--refresh_token',
+required_args = parser.add_argument_group('required arguments')
+required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')
 
-parser.add_argument('--org_id',
+required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
 
-parser.add_argument('--sddc_id',
+required_args.add_argument('--sddc_id',
                     required=True,
                     help='Sddc ID')
 
@@ -54,7 +55,7 @@ parser.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')
 
-parser.add_argument('--name',
+required_args.add_argument('--name',
                     required=True,
                     help='Name of the security group to be created')
 

--- a/samples/vmc/networks_nsxt/security_group_create.py
+++ b/samples/vmc/networks_nsxt/security_group_create.py
@@ -36,14 +36,6 @@ Create a new NSX-T Group on MGW or CGW
 Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
 """
-required_args.add_argument('--org_id',
-                    required=True,
-                    help='Orgization ID')
-
-required_args.add_argument('--sddc_id',
-                    required=True,
-                    help='SDDC ID')
-
 optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')

--- a/samples/vmc/networks_nsxt/security_group_delete.py
+++ b/samples/vmc/networks_nsxt/security_group_delete.py
@@ -19,7 +19,7 @@ __vcenter_version__ = 'VMware Cloud on AWS'
 import random
 
 import requests
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy.model_client import (Expression, Group,
                                                 IPAddressExpression)

--- a/samples/vmc/networks_nsxt/security_group_delete.py
+++ b/samples/vmc/networks_nsxt/security_group_delete.py
@@ -39,14 +39,6 @@ Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
     - A NSX-T security group
 """
-required_args.add_argument('--org_id',
-                    required=True,
-                    help='Orgization ID')
-
-required_args.add_argument('--sddc_id',
-                    required=True,
-                    help='SDDC ID')
-
 optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')

--- a/samples/vmc/networks_nsxt/security_group_delete.py
+++ b/samples/vmc/networks_nsxt/security_group_delete.py
@@ -42,17 +42,18 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument('--refresh_token',
+required_args = parser.add_argument_group('required arguments')
+required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')
 
-parser.add_argument('--org_id',
+required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
 
-parser.add_argument('--sddc_id',
+required_args.add_argument('--sddc_id',
                     required=True,
-                    help='Sddc ID')
+                    help='SDDC ID')
 
 parser.add_argument('--gateway_type',
                     default='mgw',

--- a/samples/vmc/networks_nsxt/security_group_delete.py
+++ b/samples/vmc/networks_nsxt/security_group_delete.py
@@ -16,10 +16,10 @@
 __author__ = 'VMware, Inc'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
-import argparse
 import random
 
 import requests
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy.model_client import (Expression, Group,
                                                 IPAddressExpression)
@@ -39,15 +39,6 @@ Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
     - A NSX-T security group
 """
-parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-required_args = parser.add_argument_group(
-        'required arguments')
-required_args.add_argument('--refresh_token',
-                    required=True,
-                    help='Refresh token obtained from CSP')
-
 required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
@@ -56,11 +47,11 @@ required_args.add_argument('--sddc_id',
                     required=True,
                     help='SDDC ID')
 
-parser.add_argument('--gateway_type',
+optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')
 
-parser.add_argument('--group_id',
+optional_args.add_argument('--group_id',
                     help='ID of the group to be deleted')
 
 args = parser.parse_args()

--- a/samples/vmc/networks_nsxt/security_group_delete.py
+++ b/samples/vmc/networks_nsxt/security_group_delete.py
@@ -42,7 +42,8 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-required_args = parser.add_argument_group('required arguments')
+required_args = parser.add_argument_group(
+        'required arguments')
 required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/security_group_list.py
+++ b/samples/vmc/networks_nsxt/security_group_list.py
@@ -34,14 +34,6 @@ List all Network Security Groups
 Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
 """
-required_args.add_argument('--org_id',
-                    required=True,
-                    help='Orgization ID')
-
-required_args.add_argument('--sddc_id',
-                    required=True,
-                    help='SDDC ID')
-
 optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')

--- a/samples/vmc/networks_nsxt/security_group_list.py
+++ b/samples/vmc/networks_nsxt/security_group_list.py
@@ -17,8 +17,8 @@ __author__ = 'VMware, Inc'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
 import requests
-import argparse
 
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from vmware.vapi.bindings.struct import PrettyPrinter
@@ -34,15 +34,6 @@ List all Network Security Groups
 Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
 """
-parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-required_args = parser.add_argument_group(
-        'required arguments')
-required_args.add_argument('--refresh_token',
-                    required=True,
-                    help='Refresh token obtained from CSP')
-
 required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
@@ -51,7 +42,7 @@ required_args.add_argument('--sddc_id',
                     required=True,
                     help='SDDC ID')
 
-parser.add_argument('--gateway_type',
+optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')
 

--- a/samples/vmc/networks_nsxt/security_group_list.py
+++ b/samples/vmc/networks_nsxt/security_group_list.py
@@ -37,7 +37,8 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-required_args = parser.add_argument_group('required arguments')
+required_args = parser.add_argument_group(
+        'required arguments')
 required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/security_group_list.py
+++ b/samples/vmc/networks_nsxt/security_group_list.py
@@ -18,7 +18,7 @@ __vcenter_version__ = 'VMware Cloud on AWS'
 
 import requests
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from vmware.vapi.bindings.struct import PrettyPrinter

--- a/samples/vmc/networks_nsxt/security_group_list.py
+++ b/samples/vmc/networks_nsxt/security_group_list.py
@@ -37,17 +37,18 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument('--refresh_token',
+required_args = parser.add_argument_group('required arguments')
+required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')
 
-parser.add_argument('--org_id',
+required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
 
-parser.add_argument('--sddc_id',
+required_args.add_argument('--sddc_id',
                     required=True,
-                    help='Sddc ID')
+                    help='SDDC ID')
 
 parser.add_argument('--gateway_type',
                     default='mgw',

--- a/samples/vmc/networks_nsxt/security_group_update.py
+++ b/samples/vmc/networks_nsxt/security_group_update.py
@@ -40,14 +40,6 @@ Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
     - A NSX-T security group
 """
-required_args.add_argument('--org_id',
-                    required=True,
-                    help='Orgization ID')
-
-required_args.add_argument('--sddc_id',
-                    required=True,
-                    help='SDDC ID')
-
 optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')

--- a/samples/vmc/networks_nsxt/security_group_update.py
+++ b/samples/vmc/networks_nsxt/security_group_update.py
@@ -43,7 +43,8 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-required_args = parser.add_argument_group('required arguments')
+required_args = parser.add_argument_group(
+        'required arguments')
 required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/security_group_update.py
+++ b/samples/vmc/networks_nsxt/security_group_update.py
@@ -16,10 +16,10 @@
 __author__ = 'VMware, Inc'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
-import argparse
 import random
 
 import requests
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.nsx_policy.infra_client import Domains
 from com.vmware.nsx_policy.model_client import (Expression, Group,
                                                 IPAddressExpression)
@@ -40,15 +40,6 @@ Sample Prerequisites:
     - SDDC deployed in VMware Cloud on AWS
     - A NSX-T security group
 """
-parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-required_args = parser.add_argument_group(
-        'required arguments')
-required_args.add_argument('--refresh_token',
-                    required=True,
-                    help='Refresh token obtained from CSP')
-
 required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
@@ -57,11 +48,11 @@ required_args.add_argument('--sddc_id',
                     required=True,
                     help='SDDC ID')
 
-parser.add_argument('--gateway_type',
+optional_args.add_argument('--gateway_type',
                     default='mgw',
                     help='Gateway type. Either mgw or cgw')
 
-parser.add_argument('--group_id',
+optional_args.add_argument('--group_id',
                     help='ID of the group to be updated')
 
 required_args.add_argument('--name',

--- a/samples/vmc/networks_nsxt/security_group_update.py
+++ b/samples/vmc/networks_nsxt/security_group_update.py
@@ -43,17 +43,18 @@ Sample Prerequisites:
 parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument('--refresh_token',
+required_args = parser.add_argument_group('required arguments')
+required_args.add_argument('--refresh_token',
                     required=True,
                     help='Refresh token obtained from CSP')
 
-parser.add_argument('--org_id',
+required_args.add_argument('--org_id',
                     required=True,
                     help='Orgization ID')
 
-parser.add_argument('--sddc_id',
+required_args.add_argument('--sddc_id',
                     required=True,
-                    help='Sddc ID')
+                    help='SDDC ID')
 
 parser.add_argument('--gateway_type',
                     default='mgw',
@@ -62,7 +63,7 @@ parser.add_argument('--gateway_type',
 parser.add_argument('--group_id',
                     help='ID of the group to be updated')
 
-parser.add_argument('--name',
+required_args.add_argument('--name',
                     required=True,
                     help='New name of the security group to be updated')
 

--- a/samples/vmc/networks_nsxt/segments_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/segments_firewall_crud.py
@@ -37,17 +37,18 @@ class NSXPolicySegmentFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('--refresh_token',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')
 
-        parser.add_argument('--org_id',
+        required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')
 
-        parser.add_argument('--sddc_id',
+        required_args.add_argument('--sddc_id',
                             required=True,
-                            help='Sddc ID')
+                            help='SDDC ID')
 
         args = parser.parse_args()
 

--- a/samples/vmc/networks_nsxt/segments_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/segments_firewall_crud.py
@@ -15,9 +15,8 @@
 
 __author__ = 'VMware, Inc.'
 
-
-import argparse
 import requests
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import Rule
 from vmware.vapi.bindings.struct import PrettyPrinter as NsxPrettyPrinter
@@ -34,15 +33,6 @@ class NSXPolicySegmentFirewall(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('--refresh_token',
-                            required=True,
-                            help='Refresh token obtained from CSP')
-
         required_args.add_argument('--org_id',
                             required=True,
                             help='Orgization ID')

--- a/samples/vmc/networks_nsxt/segments_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/segments_firewall_crud.py
@@ -16,7 +16,7 @@
 __author__ = 'VMware, Inc.'
 
 import requests
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from com.vmware.nsx_policy_client_for_vmc import create_nsx_policy_client_for_vmc
 from com.vmware.nsx_policy.model_client import Rule
 from vmware.vapi.bindings.struct import PrettyPrinter as NsxPrettyPrinter

--- a/samples/vmc/networks_nsxt/segments_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/segments_firewall_crud.py
@@ -37,7 +37,8 @@ class NSXPolicySegmentFirewall(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh_token',
                             required=True,
                             help='Refresh token obtained from CSP')

--- a/samples/vmc/networks_nsxt/segments_firewall_crud.py
+++ b/samples/vmc/networks_nsxt/segments_firewall_crud.py
@@ -33,14 +33,6 @@ class NSXPolicySegmentFirewall(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org_id',
-                            required=True,
-                            help='Orgization ID')
-
-        required_args.add_argument('--sddc_id',
-                            required=True,
-                            help='SDDC ID')
-
         args = parser.parse_args()
 
         self.nsx_client = create_nsx_policy_client_for_vmc(

--- a/samples/vmc/networks_nsxv/dns_crud.py
+++ b/samples/vmc/networks_nsxv/dns_crud.py
@@ -33,17 +33,19 @@ class DNSCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument('-r', '--refresh-token',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')
 
-        parser.add_argument('-o', '--org-id',
+        required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
 
-        parser.add_argument('-s', '--sddc-id',
+        required_args.add_argument('--sddc-id',
                             required=True,
-                            help='Sddc Identifier.')
+                            help='SDDC Identifier.')
 
         parser.add_argument('--use-compute-gateway',
                             action='store_true',
@@ -51,7 +53,7 @@ class DNSCrud(object):
                             help='Use compute gateway. Default is using '
                                  'management gateway')
 
-        parser.add_argument('-c', '--cleardata',
+        parser.add_argument('--cleardata',
                             action='store_true',
                             help='Clean up after sample run')
         args = parser.parse_args()

--- a/samples/vmc/networks_nsxv/dns_crud.py
+++ b/samples/vmc/networks_nsxv/dns_crud.py
@@ -15,7 +15,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import DnsForwarders
 from vmware.vapi.vmc.client import create_vmc_client
 

--- a/samples/vmc/networks_nsxv/dns_crud.py
+++ b/samples/vmc/networks_nsxv/dns_crud.py
@@ -15,8 +15,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import DnsForwarders
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -31,15 +30,6 @@ class DNSCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('--refresh-token',
-                            required=True,
-                            help='VMware Cloud API refresh token')
-
         required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
@@ -48,13 +38,13 @@ class DNSCrud(object):
                             required=True,
                             help='SDDC Identifier.')
 
-        parser.add_argument('--use-compute-gateway',
+        optional_args.add_argument('--use-compute-gateway',
                             action='store_true',
                             default=False,
                             help='Use compute gateway. Default is using '
                                  'management gateway')
 
-        parser.add_argument('--cleardata',
+        optional_args.add_argument('--cleardata',
                             action='store_true',
                             help='Clean up after sample run')
         args = parser.parse_args()

--- a/samples/vmc/networks_nsxv/dns_crud.py
+++ b/samples/vmc/networks_nsxv/dns_crud.py
@@ -30,14 +30,6 @@ class DNSCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org-id',
-                            required=True,
-                            help='Organization identifier.')
-
-        required_args.add_argument('--sddc-id',
-                            required=True,
-                            help='SDDC Identifier.')
-
         optional_args.add_argument('--use-compute-gateway',
                             action='store_true',
                             default=False,

--- a/samples/vmc/networks_nsxv/dns_crud.py
+++ b/samples/vmc/networks_nsxv/dns_crud.py
@@ -34,7 +34,8 @@ class DNSCrud(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')

--- a/samples/vmc/networks_nsxv/expose_public_ip.py
+++ b/samples/vmc/networks_nsxv/expose_public_ip.py
@@ -36,14 +36,6 @@ class ExposePublicIP(object):
     """
 
     def __init__(self):
-        required_args.add_argument('--org-id',
-                            required=True,
-                            help='Organization identifier.')
-
-        required_args.add_argument('--sddc-id',
-                            required=True,
-                            help='SDDC Identifier.')
-
         optional_args.add_argument('--notes',
                             default='Sample public IP ' + str(random.randint(0, 100)),
                             help='Notes of the new public IP')

--- a/samples/vmc/networks_nsxv/expose_public_ip.py
+++ b/samples/vmc/networks_nsxv/expose_public_ip.py
@@ -16,9 +16,9 @@
 __author__ = 'VMware, Inc.'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
-import argparse
 import random
 
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import *
 from vmware.vapi.vmc.client import create_vmc_client
 from samples.vmc.helpers.vmc_task_helper import wait_for_task
@@ -36,15 +36,6 @@ class ExposePublicIP(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('--refresh-token',
-                            required=True,
-                            help='VMware Cloud API refresh token')
-
         required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
@@ -53,15 +44,15 @@ class ExposePublicIP(object):
                             required=True,
                             help='SDDC Identifier.')
 
-        parser.add_argument('--notes',
+        optional_args.add_argument('--notes',
                             default='Sample public IP ' + str(random.randint(0, 100)),
                             help='Notes of the new public IP')
 
-        parser.add_argument('--fw-rule-name',
+        optional_args.add_argument('--fw-rule-name',
                             default='Sample firewall rule ' + str(random.randint(0, 100)),
                             help='Name of the compute gae')
 
-        parser.add_argument('--nat-rule-description',
+        optional_args.add_argument('--nat-rule-description',
                             default='Sample NAT rule ' + str(random.randint(0, 100)),
                             help='Description for the NAT rule')
 
@@ -69,7 +60,7 @@ class ExposePublicIP(object):
                             required=True,
                             help='Private IP of the VM')
 
-        parser.add_argument('--cleardata',
+        optional_args.add_argument('--cleardata',
                             action='store_true',
                             help='Clean up after sample run')
         args = parser.parse_args()

--- a/samples/vmc/networks_nsxv/expose_public_ip.py
+++ b/samples/vmc/networks_nsxv/expose_public_ip.py
@@ -39,7 +39,8 @@ class ExposePublicIP(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')

--- a/samples/vmc/networks_nsxv/expose_public_ip.py
+++ b/samples/vmc/networks_nsxv/expose_public_ip.py
@@ -38,17 +38,19 @@ class ExposePublicIP(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument('-r', '--refresh-token',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')
 
-        parser.add_argument('-o', '--org-id',
+        required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
 
-        parser.add_argument('-s', '--sddc-id',
+        required_args.add_argument('--sddc-id',
                             required=True,
-                            help='Sddc Identifier.')
+                            help='SDDC Identifier.')
 
         parser.add_argument('--notes',
                             default='Sample public IP ' + str(random.randint(0, 100)),
@@ -62,11 +64,11 @@ class ExposePublicIP(object):
                             default='Sample NAT rule ' + str(random.randint(0, 100)),
                             help='Description for the NAT rule')
 
-        parser.add_argument('--internal-ip',
+        required_args.add_argument('--internal-ip',
                             required=True,
                             help='Private IP of the VM')
 
-        parser.add_argument('-c', '--cleardata',
+        parser.add_argument('--cleardata',
                             action='store_true',
                             help='Clean up after sample run')
         args = parser.parse_args()

--- a/samples/vmc/networks_nsxv/firewall_rules_crud.py
+++ b/samples/vmc/networks_nsxv/firewall_rules_crud.py
@@ -14,8 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import (AddressFWSourceDestination,
                                          Application, FirewallRules,
                                          Nsxfirewallrule, Nsxfirewallservice)
@@ -32,35 +31,25 @@ class FirewallRulesCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
             '--sddc-id', required=True, help='Sddc Identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--rule-name',
             default='Sample Firewall Rule',
             help='Name of the new firewall rule')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--use-compute-gateway',
             action='store_true',
             default=False,
             help='Use compute gateway. Default is using '
             'management gateway')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/firewall_rules_crud.py
+++ b/samples/vmc/networks_nsxv/firewall_rules_crud.py
@@ -35,7 +35,8 @@ class FirewallRulesCrud(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/networks_nsxv/firewall_rules_crud.py
+++ b/samples/vmc/networks_nsxv/firewall_rules_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import (AddressFWSourceDestination,
                                          Application, FirewallRules,
                                          Nsxfirewallrule, Nsxfirewallservice)

--- a/samples/vmc/networks_nsxv/firewall_rules_crud.py
+++ b/samples/vmc/networks_nsxv/firewall_rules_crud.py
@@ -34,17 +34,18 @@ class FirewallRulesCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument(
-            '-r',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '--sddc-id', required=True, help='Sddc Identifier.')
 
         parser.add_argument(
             '--rule-name',
@@ -59,7 +60,6 @@ class FirewallRulesCrud(object):
             'management gateway')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/firewall_rules_crud.py
+++ b/samples/vmc/networks_nsxv/firewall_rules_crud.py
@@ -31,12 +31,6 @@ class FirewallRulesCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='Sddc Identifier.')
-
         optional_args.add_argument(
             '--rule-name',
             default='Sample Firewall Rule',

--- a/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
+++ b/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
@@ -33,7 +33,8 @@ class IpsecVPNsCrud(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
+++ b/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import Ipsec, IpsecSite, IpsecSites, Subnets
 from vmware.vapi.vmc.client import create_vmc_client
 

--- a/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
+++ b/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
@@ -32,17 +32,18 @@ class IpsecVPNsCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument(
-            '-r',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '--sddc-id', required=True, help='SDDC Identifier.')
 
         parser.add_argument(
             '--use-compute-gateway',
@@ -82,7 +83,6 @@ class IpsecVPNsCrud(object):
             help='Pre Shared Key for the IPsec Site')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
+++ b/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
@@ -29,12 +29,6 @@ class IpsecVPNsCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='SDDC Identifier.')
-
         optional_args.add_argument(
             '--use-compute-gateway',
             action='store_true',

--- a/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
+++ b/samples/vmc/networks_nsxv/ipsec_vpns_crud.py
@@ -14,8 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import Ipsec, IpsecSite, IpsecSites, Subnets
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -30,60 +29,50 @@ class IpsecVPNsCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
             '--sddc-id', required=True, help='SDDC Identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--use-compute-gateway',
             action='store_true',
             default=False,
             help='Use compute gateway. Default is using '
             'management gateway')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--vpn-name',
             default='Sample IPsec VPN',
             help='Name of the new VPN')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--public-ip',
             default='10.10.10.10',
             help='IP (IPv4) address or FQDN of the Peer')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--private-ip',
             default='192.168.10.10',
             help='Local IP of the IPsec Site')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--remote-networks',
             default='192.168.20.10/24',
             help='Peer subnets for which VPN is configured')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--local-networks',
             default='192.168.30.10/24',
             help='Local subnets for which VPN is configured')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--key',
             default='00000000',
             help='Pre Shared Key for the IPsec Site')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/logical_network_crud.py
+++ b/samples/vmc/networks_nsxv/logical_network_crud.py
@@ -36,17 +36,17 @@ class LogicalNetworkCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument(
-            '-r',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '--sddc-id', required=True, help='Sddc Identifier.')
 
         parser.add_argument(
             '--network-name',
@@ -64,7 +64,6 @@ class LogicalNetworkCrud(object):
             help='DHCP IP range for the logical network')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/logical_network_crud.py
+++ b/samples/vmc/networks_nsxv/logical_network_crud.py
@@ -33,12 +33,6 @@ class LogicalNetworkCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='Sddc Identifier.')
-
         optional_args.add_argument(
             '--network-name',
             default='Sample Logical Network',

--- a/samples/vmc/networks_nsxv/logical_network_crud.py
+++ b/samples/vmc/networks_nsxv/logical_network_crud.py
@@ -14,8 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import (L2Extension, SddcNetwork,
                                          SddcNetworkAddressGroups,
                                          SddcNetworkAddressGroup,
@@ -34,37 +33,28 @@ class LogicalNetworkCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
             '--sddc-id', required=True, help='Sddc Identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--network-name',
             default='Sample Logical Network',
             help='Name of the new logical network')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--subnet',
             default='192.168.100.1/24',
             help='Logical network subnet')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--dhcp-range',
             default='192.168.100.2-192.168.100.254',
             help='DHCP IP range for the logical network')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/logical_network_crud.py
+++ b/samples/vmc/networks_nsxv/logical_network_crud.py
@@ -36,7 +36,8 @@ class LogicalNetworkCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/networks_nsxv/logical_network_crud.py
+++ b/samples/vmc/networks_nsxv/logical_network_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import (L2Extension, SddcNetwork,
                                          SddcNetworkAddressGroups,
                                          SddcNetworkAddressGroup,

--- a/samples/vmc/networks_nsxv/nat_rule_crud.py
+++ b/samples/vmc/networks_nsxv/nat_rule_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import Nsxnatrule, NatRules
 from vmware.vapi.vmc.client import create_vmc_client
 

--- a/samples/vmc/networks_nsxv/nat_rule_crud.py
+++ b/samples/vmc/networks_nsxv/nat_rule_crud.py
@@ -29,12 +29,6 @@ class NatRuleCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='SDDC Identifier.')
-
         optional_args.add_argument(
             '--public-ip', help='Public IP range for the NAT rule')
 

--- a/samples/vmc/networks_nsxv/nat_rule_crud.py
+++ b/samples/vmc/networks_nsxv/nat_rule_crud.py
@@ -32,7 +32,8 @@ class NatRuleCrud(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/networks_nsxv/nat_rule_crud.py
+++ b/samples/vmc/networks_nsxv/nat_rule_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import Nsxnatrule, NatRules
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -29,36 +29,26 @@ class NatRuleCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
             '--sddc-id', required=True, help='SDDC Identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--public-ip', help='Public IP range for the NAT rule')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--rule-description',
             default='Sample NAT rule',
             help='Description for the rule')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--internal-ip',
             default='192.168.200.1/24',
             help='NAT rule subnet')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/nat_rule_crud.py
+++ b/samples/vmc/networks_nsxv/nat_rule_crud.py
@@ -31,17 +31,18 @@ class NatRuleCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument(
-            '-r',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '--sddc-id', required=True, help='SDDC Identifier.')
 
         parser.add_argument(
             '--public-ip', help='Public IP range for the NAT rule')
@@ -57,7 +58,6 @@ class NatRuleCrud(object):
             help='NAT rule subnet')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/public_ip_crud.py
+++ b/samples/vmc/networks_nsxv/public_ip_crud.py
@@ -31,12 +31,6 @@ class PublicIPsCrud(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='Sddc Identifier.')
-
         optional_args.add_argument(
             '--notes',
             default='Sample public IP',

--- a/samples/vmc/networks_nsxv/public_ip_crud.py
+++ b/samples/vmc/networks_nsxv/public_ip_crud.py
@@ -34,7 +34,8 @@ class PublicIPsCrud(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/networks_nsxv/public_ip_crud.py
+++ b/samples/vmc/networks_nsxv/public_ip_crud.py
@@ -33,17 +33,18 @@ class PublicIPsCrud(object):
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        parser.add_argument(
-            '-r',
+
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '--sddc-id', required=True, help='Sddc Identifier.')
 
         parser.add_argument(
             '--notes',
@@ -51,7 +52,6 @@ class PublicIPsCrud(object):
             help='Notes of the new public IP')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/public_ip_crud.py
+++ b/samples/vmc/networks_nsxv/public_ip_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import SddcAllocatePublicIpSpec
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -31,28 +31,18 @@ class PublicIPsCrud(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
             '--sddc-id', required=True, help='Sddc Identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--notes',
             default='Sample public IP',
             help='Notes of the new public IP')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/networks_nsxv/public_ip_crud.py
+++ b/samples/vmc/networks_nsxv/public_ip_crud.py
@@ -14,7 +14,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import SddcAllocatePublicIpSpec
 from vmware.vapi.vmc.client import create_vmc_client
 

--- a/samples/vmc/orgs/organization_operations.py
+++ b/samples/vmc/orgs/organization_operations.py
@@ -15,9 +15,9 @@
 __author__ = 'VMware, Inc.'
 
 import requests
+import argparse
 import atexit
 
-from samples.vmc.helpers.sample_cli import parser
 from vmware.vapi.vmc.client import create_vmc_client
 
 
@@ -36,6 +36,15 @@ class OperationsOnOrganizations(object):
         self.refresh_token = None
 
     def options(self):
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        required_args = parser.add_argument_group(
+            'required arguments')
+        required_args.add_argument(
+            '--refresh_token',
+            required=True,
+            help='VMware Cloud API refresh token')
+
         self.refresh_token = parser.parse_args().refresh_token
 
     def setup(self):

--- a/samples/vmc/orgs/organization_operations.py
+++ b/samples/vmc/orgs/organization_operations.py
@@ -39,8 +39,8 @@ class OperationsOnOrganizations(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument(
-            '-r',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')

--- a/samples/vmc/orgs/organization_operations.py
+++ b/samples/vmc/orgs/organization_operations.py
@@ -39,7 +39,8 @@ class OperationsOnOrganizations(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/orgs/organization_operations.py
+++ b/samples/vmc/orgs/organization_operations.py
@@ -15,9 +15,9 @@
 __author__ = 'VMware, Inc.'
 
 import requests
-import argparse
 import atexit
 
+from samples.vmc.helpers.sample_cli import parser
 from vmware.vapi.vmc.client import create_vmc_client
 
 
@@ -36,16 +36,6 @@ class OperationsOnOrganizations(object):
         self.refresh_token = None
 
     def options(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         self.refresh_token = parser.parse_args().refresh_token
 
     def setup(self):

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -46,7 +46,8 @@ class AddRemoveHosts(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -15,10 +15,10 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
 import atexit
 import requests
 
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import EsxConfig, ErrorResponse
 from com.vmware.vapi.std.errors_client import InvalidRequest
 from vmware.vapi.vmc.client import create_vmc_client
@@ -43,15 +43,6 @@ class AddRemoveHosts(object):
         self.interval_sec = None
 
     def options(self):
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument('--refresh-token',
-                            required=True,
-                            help='VMware Cloud API refresh token')
-
         required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
@@ -60,7 +51,7 @@ class AddRemoveHosts(object):
                             required=True,
                             help='Sddc Identifier.')
 
-        parser.add_argument('--interval-sec',
+        optional_args.add_argument('--interval-sec',
                             default=60,
                             help='Task pulling interval in sec')
 

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -46,19 +46,20 @@ class AddRemoveHosts(object):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        parser.add_argument('-r', '--refresh-token',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--refresh-token',
                             required=True,
                             help='VMware Cloud API refresh token')
 
-        parser.add_argument('-o', '--org-id',
+        required_args.add_argument('--org-id',
                             required=True,
                             help='Organization identifier.')
 
-        parser.add_argument('-s', '--sddc-id',
+        required_args.add_argument('--sddc-id',
                             required=True,
                             help='Sddc Identifier.')
 
-        parser.add_argument('-i', '--interval-sec',
+        parser.add_argument('--interval-sec',
                             default=60,
                             help='Task pulling interval in sec')
 

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -43,14 +43,6 @@ class AddRemoveHosts(object):
         self.interval_sec = None
 
     def options(self):
-        required_args.add_argument('--org-id',
-                            required=True,
-                            help='Organization identifier.')
-
-        required_args.add_argument('--sddc-id',
-                            required=True,
-                            help='Sddc Identifier.')
-
         optional_args.add_argument('--interval-sec',
                             default=60,
                             help='Task pulling interval in sec')

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -18,7 +18,7 @@ __author__ = 'VMware, Inc.'
 import atexit
 import requests
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+from samples.vmc.helpers.sample_cli import parser, optional_args
 from com.vmware.vmc.model_client import EsxConfig, ErrorResponse
 from com.vmware.vapi.std.errors_client import InvalidRequest
 from vmware.vapi.vmc.client import create_vmc_client

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -15,11 +15,11 @@
 __author__ = 'VMware, Inc.'
 __vcenter_version__ = 'VMware Cloud on AWS'
 
-import argparse
 
 from com.vmware.vapi.std.errors_client import NotFound
 from com.vmware.vmc.model_client import ErrorResponse
 from six.moves.urllib import parse
+from samples.vmc.helpers.sample_cli import parser, required_args
 from vmware.vapi.vmc.client import create_vmc_client
 from vmware.vapi.vsphere.client import create_vsphere_client
 
@@ -35,19 +35,11 @@ class ConnectTovSphereWithDefaultCredentials(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser()
-        required_args = parser.add_argument_group(
-            'required arguments')
         required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
+            '--org-id', required=True, help='Organization identifier.')
 
         required_args.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '-s', '--sddc-id', required=True, help='SDDC Identifier.')
+            '--sddc-id', required=True, help='SDDC Identifier.')
         args = parser.parse_args()
 
         self.refresh_token = args.refresh_token

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -35,11 +35,6 @@ class ConnectTovSphereWithDefaultCredentials(object):
     """
 
     def __init__(self):
-        required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
-
-        required_args.add_argument(
-            '--sddc-id', required=True, help='SDDC Identifier.')
         args = parser.parse_args()
 
         self.refresh_token = args.refresh_token

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -19,7 +19,7 @@ __vcenter_version__ = 'VMware Cloud on AWS'
 from com.vmware.vapi.std.errors_client import NotFound
 from com.vmware.vmc.model_client import ErrorResponse
 from six.moves.urllib import parse
-from samples.vmc.helpers.sample_cli import parser, required_args
+from samples.vmc.helpers.sample_cli import parser
 from vmware.vapi.vmc.client import create_vmc_client
 from vmware.vapi.vsphere.client import create_vsphere_client
 

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -36,7 +36,8 @@ class ConnectTovSphereWithDefaultCredentials(object):
 
     def __init__(self):
         parser = argparse.ArgumentParser()
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -36,17 +36,17 @@ class ConnectTovSphereWithDefaultCredentials(object):
 
     def __init__(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            '-r',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
+        required_args.add_argument(
             '-o', '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
-            '-s', '--sddc-id', required=True, help='Sddc Identifier.')
+        required_args.add_argument(
+            '-s', '--sddc-id', required=True, help='SDDC Identifier.')
         args = parser.parse_args()
 
         self.refresh_token = args.refresh_token

--- a/samples/vmc/sddc/deploy_ovf_template.py
+++ b/samples/vmc/sddc/deploy_ovf_template.py
@@ -41,28 +41,29 @@ class DeployOvfTemplate:
         self.vm_name = 'deployed-vm-' + str(generate_random_uuid())
 
         parser = sample_cli.build_arg_parser()
-        parser.add_argument('--libitemname',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument('--libitemname',
                             required=True,
-                            help='(Required) The name of the library item to deploy. '
+                            help='The name of the library item to deploy. '
                                  'The library item should contain an OVF package.')
 
         parser.add_argument('--vmname',
                             default=self.vm_name,
-                            help='(Optional) The name of the Virtual Machine to be deployed. '
+                            help='The name of the Virtual Machine to be deployed. '
                                  'Default: "{}"'.format(self.vm_name))
 
         parser.add_argument('--resourcepoolname',
                             default='Compute-ResourcePool',
-                            help='(Optional) The name of the resource pool to be used. '
+                            help='The name of the resource pool to be used. '
                                  'Default: "Compute-ResourcePool"')
 
         parser.add_argument('--foldername',
                             default='Workloads',
-                            help='(Optional) The name of the folder to be used. '
+                            help='The name of the folder to be used. '
                                  'Default: "Workloads"')
 
         parser.add_argument('--opaquenetworkname',
-                            help='(Optional) The name of the opaque network to be added '
+                            help='The name of the opaque network to be added '
                                  'to the deployed vm')
 
         args = sample_util.process_cli_args(parser.parse_args())

--- a/samples/vmc/sddc/deploy_ovf_template.py
+++ b/samples/vmc/sddc/deploy_ovf_template.py
@@ -41,7 +41,8 @@ class DeployOvfTemplate:
         self.vm_name = 'deployed-vm-' + str(generate_random_uuid())
 
         parser = sample_cli.build_arg_parser()
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument('--libitemname',
                             required=True,
                             help='The name of the library item to deploy. '

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -33,8 +33,7 @@ class CreateDeleteSDDC(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+        parser = argparse.ArgumentParser()
 
         required_args = parser.add_argument_group(
             'required arguments')

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -36,17 +36,16 @@ class CreateDeleteSDDC(object):
     def __init__(self):
         parser = argparse.ArgumentParser()
 
-        parser.add_argument(
-            '-r',
+        required_args = parser.add_argument_group('required arguments')
+        required_args.add_argument(
             '--refresh-token',
             required=True,
             help='VMware Cloud API refresh token')
 
-        parser.add_argument(
-            '-o', '--org-id', required=True, help='Organization identifier.')
+        required_args.add_argument(
+            '--org-id', required=True, help='Organization identifier.')
 
         parser.add_argument(
-            '-sn',
             '--sddc-name',
             help="Name of the SDDC to be created. "
             "Default is 'Sample SDDC xx'")
@@ -54,31 +53,26 @@ class CreateDeleteSDDC(object):
         parser.add_argument('--region', default='US_WEST_2', help='AWS Region')
 
         parser.add_argument(
-            '-i',
             '--interval-sec',
             default=60,
             help='Task pulling interval in sec')
 
         parser.add_argument(
-            '-ls',
             '--listsddc',
             action='store_true',
             help='List SDDCs in the specified Org')
 
         parser.add_argument(
-            '-cs',
             '--createsddc',
             action='store_true',
             help='Create an SDDC in the specified Org')
 
         parser.add_argument(
-            '-ds',
             '--deletesddc',
             action='store_true',
             help='Deletes the SDDC in the specified Org ')
 
         parser.add_argument(
-            '-c',
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -36,7 +36,8 @@ class CreateDeleteSDDC(object):
     def __init__(self):
         parser = argparse.ArgumentParser()
 
-        required_args = parser.add_argument_group('required arguments')
+        required_args = parser.add_argument_group(
+            'required arguments')
         required_args.add_argument(
             '--refresh-token',
             required=True,

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -16,11 +16,11 @@ __author__ = 'VMware, Inc.'
 
 import os
 from random import randrange
+import argparse
 
 from com.vmware.vapi.std.errors_client import InvalidRequest
 from com.vmware.vmc.model_client import AwsSddcConfig, ErrorResponse, AccountLinkSddcConfig, SddcConfig
 from vmware.vapi.vmc.client import create_vmc_client
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from samples.vmc.helpers.vmc_task_helper import wait_for_task
 
 
@@ -33,8 +33,23 @@ class CreateDeleteSDDC(object):
     """
 
     def __init__(self):
+        parser = argparse.ArgumentParser(
+        description='Standard Arguments for talking to vCenter')
+
+        required_args = parser.add_argument_group(
+            'required arguments')
+        optional_args = parser.add_argument_group(
+            'optional arguments')
+
         required_args.add_argument(
-            '--org-id', required=True, help='Organization identifier.')
+            '--refresh_token',
+            required=True,
+            help='Refresh token obtained from CSP')
+
+        required_args.add_argument(
+            '--org_id',
+            required=True,
+            help='Organization identifier.')
 
         optional_args.add_argument(
             '--sddc-name',

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -14,14 +14,13 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
 import os
 from random import randrange
 
 from com.vmware.vapi.std.errors_client import InvalidRequest
 from com.vmware.vmc.model_client import AwsSddcConfig, ErrorResponse, AccountLinkSddcConfig, SddcConfig
 from vmware.vapi.vmc.client import create_vmc_client
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from samples.vmc.helpers.vmc_task_helper import wait_for_task
 
 
@@ -34,46 +33,37 @@ class CreateDeleteSDDC(object):
     """
 
     def __init__(self):
-        parser = argparse.ArgumentParser()
-
-        required_args = parser.add_argument_group(
-            'required arguments')
-        required_args.add_argument(
-            '--refresh-token',
-            required=True,
-            help='VMware Cloud API refresh token')
-
         required_args.add_argument(
             '--org-id', required=True, help='Organization identifier.')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--sddc-name',
             help="Name of the SDDC to be created. "
             "Default is 'Sample SDDC xx'")
 
-        parser.add_argument('--region', default='US_WEST_2', help='AWS Region')
+        optional_args.add_argument('--region', default='US_WEST_2', help='AWS Region')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--interval-sec',
             default=60,
             help='Task pulling interval in sec')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--listsddc',
             action='store_true',
             help='List SDDCs in the specified Org')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--createsddc',
             action='store_true',
             help='Create an SDDC in the specified Org')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--deletesddc',
             action='store_true',
             help='Deletes the SDDC in the specified Org ')
 
-        parser.add_argument(
+        optional_args.add_argument(
             '--cleardata',
             action='store_true',
             help='Clean up after sample run')

--- a/samples/vmc/tasks/cancel_task.py
+++ b/samples/vmc/tasks/cancel_task.py
@@ -13,7 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args
+import argparse
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -25,13 +25,26 @@ Sample Prerequisites:
     - A running task
 """
 
-required_args.add_argument('--org-id',
-                    required=True,
-                    help='Organization identifier.')
+parser = argparse.ArgumentParser(
+        description='Standard Arguments for talking to vCenter')
 
-required_args.add_argument('--task-id',
-                    required=True,
-                    help='Task ID to be cancelled')
+required_args = parser.add_argument_group(
+        'required arguments')
+
+required_args.add_argument(
+        '--refresh_token',
+        required=True,
+        help='Refresh token obtained from CSP')
+
+required_args.add_argument(
+        '--org-id',
+        required=True,
+        help='Organization identifier.')
+
+required_args.add_argument(
+        '--task-id',
+        required=True,
+        help='Task ID to be cancelled')
 
 args = parser.parse_args()
 

--- a/samples/vmc/tasks/cancel_task.py
+++ b/samples/vmc/tasks/cancel_task.py
@@ -26,7 +26,7 @@ Sample Prerequisites:
 """
 
 parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 required_args = parser.add_argument_group(
         'required arguments')

--- a/samples/vmc/tasks/cancel_task.py
+++ b/samples/vmc/tasks/cancel_task.py
@@ -28,16 +28,16 @@ Sample Prerequisites:
 
 parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-parser.add_argument('--refresh-token',
+required_args = parser.add_argument_group('required arguments')
+required_args.add_argument('--refresh-token',
                     required=True,
                     help='VMware Cloud API refresh token')
 
-parser.add_argument('--org-id',
+required_args.add_argument('--org-id',
                     required=True,
                     help='Organization identifier.')
 
-parser.add_argument('--task-id',
+required_args.add_argument('--task-id',
                     required=True,
                     help='Task ID to be cancelled')
 

--- a/samples/vmc/tasks/cancel_task.py
+++ b/samples/vmc/tasks/cancel_task.py
@@ -13,8 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -25,14 +24,6 @@ Sample Prerequisites:
     - VMware Cloud on AWS console API access
     - A running task
 """
-
-parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group(
-            'required arguments')
-required_args.add_argument('--refresh-token',
-                    required=True,
-                    help='VMware Cloud API refresh token')
 
 required_args.add_argument('--org-id',
                     required=True,

--- a/samples/vmc/tasks/cancel_task.py
+++ b/samples/vmc/tasks/cancel_task.py
@@ -28,7 +28,8 @@ Sample Prerequisites:
 
 parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group('required arguments')
+required_args = parser.add_argument_group(
+            'required arguments')
 required_args.add_argument('--refresh-token',
                     required=True,
                     help='VMware Cloud API refresh token')

--- a/samples/vmc/tasks/list_tasks.py
+++ b/samples/vmc/tasks/list_tasks.py
@@ -28,8 +28,10 @@ Sample Prerequisites:
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group('required arguments')
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+required_args = parser.add_argument_group(
+    'required arguments')
 
 required_args.add_argument('--refresh-token',
                     required=True,

--- a/samples/vmc/tasks/list_tasks.py
+++ b/samples/vmc/tasks/list_tasks.py
@@ -13,7 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args
+import argparse
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -28,7 +28,7 @@ accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
 parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 required_args = parser.add_argument_group(
         'required arguments')

--- a/samples/vmc/tasks/list_tasks.py
+++ b/samples/vmc/tasks/list_tasks.py
@@ -27,13 +27,25 @@ Sample Prerequisites:
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
-required_args.add_argument('--org-id',
-                    required=True,
-                    help='Organization identifier.')
+parser = argparse.ArgumentParser(
+        description='Standard Arguments for talking to vCenter')
 
-required_args.add_argument('--task-status',
-                    help='Task status to filter. Possible values are: {} \
-                    Show all tasks if no value is passed'.format(accepted))
+required_args = parser.add_argument_group(
+        'required arguments')
+
+required_args.add_argument(
+        '--refresh_token',
+        required=True,
+        help='Refresh token obtained from CSP')
+required_args.add_argument(
+        '--org-id',
+        required=True,
+        help='Organization identifier.')
+
+required_args.add_argument(
+        '--task-status',
+        help='Task status to filter. Possible values are: {} \
+        Show all tasks if no value is passed'.format(accepted))
 
 args = parser.parse_args()
 

--- a/samples/vmc/tasks/list_tasks.py
+++ b/samples/vmc/tasks/list_tasks.py
@@ -29,16 +29,17 @@ accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+required_args = parser.add_argument_group('required arguments')
 
-parser.add_argument('--refresh-token',
+required_args.add_argument('--refresh-token',
                     required=True,
                     help='VMware Cloud API refresh token')
 
-parser.add_argument('--org-id',
+required_args.add_argument('--org-id',
                     required=True,
                     help='Organization identifier.')
 
-parser.add_argument('--task-status',
+required_args.add_argument('--task-status',
                     help='Task status to filter. Possible values are: {} \
                     Show all tasks if no value is passed'.format(accepted))
 

--- a/samples/vmc/tasks/list_tasks.py
+++ b/samples/vmc/tasks/list_tasks.py
@@ -13,8 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -27,15 +26,6 @@ Sample Prerequisites:
 
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
-
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group(
-    'required arguments')
-
-required_args.add_argument('--refresh-token',
-                    required=True,
-                    help='VMware Cloud API refresh token')
 
 required_args.add_argument('--org-id',
                     required=True,

--- a/samples/vmc/tasks/list_tasks_stg.py
+++ b/samples/vmc/tasks/list_tasks_stg.py
@@ -28,8 +28,10 @@ Sample Prerequisites:
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group('required arguments')
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+required_args = parser.add_argument_group(
+    'required arguments')
 
 required_args.add_argument('--refresh-token',
                     required=True,

--- a/samples/vmc/tasks/list_tasks_stg.py
+++ b/samples/vmc/tasks/list_tasks_stg.py
@@ -13,7 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
+import argparse
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -27,13 +27,28 @@ Sample Prerequisites:
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
-required_args.add_argument('--org-id',
-                    required=True,
-                    help='Organization identifier.')
+parser = argparse.ArgumentParser(
+        description='Standard Arguments for talking to vCenter')
 
-optional_args.add_argument('--task-status',
-                    help='Task status to filter. Possible values are: {} \
-                    Show all tasks if no value is passed'.format(accepted))
+required_args = parser.add_argument_group(
+        'required arguments')
+optional_args = parser.add_argument_group(
+        'optional arguments')
+
+required_args.add_argument(
+        '--refresh_token',
+        required=True,
+        help='Refresh token obtained from CSP')
+
+required_args.add_argument(
+        '--org-id',
+        required=True,
+        help='Organization identifier.')
+
+optional_args.add_argument(
+        '--task-status',
+        help='Task status to filter. Possible values are: {} \
+        Show all tasks if no value is passed'.format(accepted))
 
 args = parser.parse_args()
 

--- a/samples/vmc/tasks/list_tasks_stg.py
+++ b/samples/vmc/tasks/list_tasks_stg.py
@@ -29,12 +29,13 @@ accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+required_args = parser.add_argument_group('required arguments')
 
-parser.add_argument('--refresh-token',
+required_args.add_argument('--refresh-token',
                     required=True,
                     help='VMware Cloud API refresh token')
 
-parser.add_argument('--org-id',
+required_args.add_argument('--org-id',
                     required=True,
                     help='Organization identifier.')
 

--- a/samples/vmc/tasks/list_tasks_stg.py
+++ b/samples/vmc/tasks/list_tasks_stg.py
@@ -13,8 +13,7 @@
 
 __author__ = 'VMware, Inc.'
 
-import argparse
-
+from samples.vmc.helpers.sample_cli import parser, required_args, optional_args
 from com.vmware.vmc.model_client import Task
 from vmware.vapi.vmc.client import create_vmc_client
 
@@ -28,20 +27,11 @@ Sample Prerequisites:
 accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-required_args = parser.add_argument_group(
-    'required arguments')
-
-required_args.add_argument('--refresh-token',
-                    required=True,
-                    help='VMware Cloud API refresh token')
-
 required_args.add_argument('--org-id',
                     required=True,
                     help='Organization identifier.')
 
-parser.add_argument('--task-status',
+optional_args.add_argument('--task-status',
                     help='Task status to filter. Possible values are: {} \
                     Show all tasks if no value is passed'.format(accepted))
 

--- a/samples/vmc/tasks/list_tasks_stg.py
+++ b/samples/vmc/tasks/list_tasks_stg.py
@@ -28,7 +28,7 @@ accepted = [Task.STATUS_STARTED, Task.STATUS_CANCELING, Task.STATUS_FINISHED,
             Task.STATUS_FAILED, Task.STATUS_CANCELED]
 
 parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 required_args = parser.add_argument_group(
         'required arguments')

--- a/samples/vsphere/common/sample_cli.py
+++ b/samples/vsphere/common/sample_cli.py
@@ -31,7 +31,8 @@ def build_arg_parser():
     parser = argparse.ArgumentParser(
         description='Standard Arguments for talking to vCenter')
 
-    required_args = parser.add_argument_group('required arguments')
+    required_args = parser.add_argument_group(
+            'required arguments')
     required_args.add_argument('-s', '--server',
                         action='store',
                         help='vSphere service IP to connect to')

--- a/samples/vsphere/common/sample_cli.py
+++ b/samples/vsphere/common/sample_cli.py
@@ -31,15 +31,16 @@ def build_arg_parser():
     parser = argparse.ArgumentParser(
         description='Standard Arguments for talking to vCenter')
 
-    parser.add_argument('-s', '--server',
+    required_args = parser.add_argument_group('required arguments')
+    required_args.add_argument('-s', '--server',
                         action='store',
                         help='vSphere service IP to connect to')
 
-    parser.add_argument('-u', '--username',
+    required_args.add_argument('-u', '--username',
                         action='store',
                         help='Username to use when connecting to vc')
 
-    parser.add_argument('-p', '--password',
+    required_args.add_argument('-p', '--password',
                         action='store',
                         help='Password to use when connecting to vc')
 

--- a/samples/vsphere/common/sample_cli.py
+++ b/samples/vsphere/common/sample_cli.py
@@ -35,14 +35,17 @@ def build_arg_parser():
             'required arguments')
     required_args.add_argument('-s', '--server',
                         action='store',
+                        required=True,
                         help='vSphere service IP to connect to')
 
     required_args.add_argument('-u', '--username',
                         action='store',
+                        required=True,
                         help='Username to use when connecting to vc')
 
     required_args.add_argument('-p', '--password',
                         action='store',
+                        required=True,
                         help='Password to use when connecting to vc')
 
     parser.add_argument('-c', '--cleardata',


### PR DESCRIPTION
By default, all the keyword arguments are listed under the **optional arguments** section. This will lead to confusion to the user as to which arguments are _required_ and actually _optional_.

To solve this problem, I have created an argument group called **required arguments** and listed all the required args under this header.

This PR contains modifications to **VMC samples only**.