### PR TITLE
Sample for using appliance Monitoring

### DIFF
--- a/samples/vsphere/appliances/monitoring_query.py
+++ b/samples/vsphere/appliances/monitoring_query.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+* *******************************************************
+* Copyright (c) VMware, Inc. 2021. All Rights Reserved.
+* SPDX-License-Identifier: MIT
+* *******************************************************
+*
+* DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+* EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+* WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+* NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+"""
+
+__author__ = 'VMware, Inc.'
+__vcenter_version__ = '6.7+'
+
+from vmware.vapi.vsphere.client import create_vsphere_client
+from datetime import datetime, timedelta
+
+from samples.vsphere.common import (sample_cli, sample_util)
+from samples.vsphere.common.ssl_helper import get_unverified_session
+
+"""
+Description: Demonstrates monitoring api workflow
+1. List all memory and cpu counters
+2. Query and print daily averages
+"""
+
+MEMORY_CATEGORY = "com.vmware.applmgmt.mon.cat.memory"
+CPU_CATEGORY = "com.vmware.applmgmt.mon.cat.cpu"
+CATEGORIES = (MEMORY_CATEGORY, CPU_CATEGORY)
+METRIC_TITLE = "Metric"
+DAY = timedelta(days=1)
+DATE_FORMAT = "%Y-%m-%d"
+
+parser = sample_cli.build_arg_parser()
+args = sample_util.process_cli_args(parser.parse_args())
+session = get_unverified_session() if args.skipverification else None
+client = create_vsphere_client(server=args.server,
+                               username=args.username,
+                               password=args.password,
+                               session=session)
+
+# Get the Monitoring interface
+monitoring = client.appliance.Monitoring
+
+# List the available counters
+counters = monitoring.list()
+
+# Get the names of counters that relate to CPU and Memory categories
+conterIds = []
+for counter in counters:
+    if counter.category in CATEGORIES:
+        conterIds.append(counter.id)
+
+# Compute interval for last few days
+end = datetime.now()
+start = end - timedelta(days=2)
+
+# Query timeseries data
+query = monitoring.MonitoredItemDataRequest(names=conterIds,
+                            interval="DAY1",
+                            function="AVG",
+                            start_time=start,
+                            end_time=end)
+data = monitoring.query(query)
+
+
+print("Example: Query Monitoring for Timeseries Data:")
+print("-------------------\n")
+
+# Create title and row format strings
+# We need one labeled column for every day between start and end
+
+# Reserve 25 characters for the first column with metric name
+title = METRIC_TITLE + (" " * (25 - len(METRIC_TITLE)))
+columnFormat = "{0:25}"
+
+idx = 0
+timestamp = start
+# Create columns for each day
+while timestamp <= end:
+    # 24 characters per column. In the title use 10 for date and 14 padding.
+    title += timestamp.strftime(DATE_FORMAT) + " " * 14
+    columnFormat += "{{1[{}]:24}}".format(idx)
+    # increment
+    idx = idx + 1
+    timestamp = timestamp + DAY
+
+print(title)
+for item in data:
+    print(columnFormat.format(item.name, item.data))


### PR DESCRIPTION
This sample shows how to use the appliance `Monitoring` interface.

The sample calls:

1. `Monitoring.list()` API to obtain list of counters.
2. `Monitoring.query()` API to obtain CPU and Memory statistics for the
last 5 days

Sample output (table with formatted time series data):
```
vcenter server = sc2-rdops-vm06-dhcp-192-66.eng.vmware.com
vc username = administrator@vsphere.local
Example: Query Monitoring for Timeseries Data:
-------------------

Metric                   2021-01-11              2021-01-12              2021-01-13              
cpu.totalfrequency       4788.91000000003        4788.910000000093       4788.910000000022       
cpu.systemload           0.6416814159292042      0.567210599721061       0.5591065830721007      
mem.util                 12477816.737463126      12260877.439330544      12179708.608150471      
mem.total                16413756.0              16413756.0              16413756.0              
mem.usage                76.02048390059609       74.69879191167777       74.20427480553785       
cpu.util                 13.568788627868807      12.823087055205912      11.284068845256204      
cpu.steal                0.0                     0.0                     0.0                     
swap.pageRate            1.3171504645318802e-05  1.1718624350229224e-05  1.166378552013087e-05 
```