### PR TITLE
Remove suds(-jurko) dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 lxml >= 4.3.0
 pyVmomi >= 6.7
-suds ; python_version < '3'
-suds-jurko ; python_version >= '3.0'
 vapi-client-bindings == 3.6.0
 vmc-client-bindings
 nsx-python-sdk

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ setup(name='vSphere Automation SDK',
       license='MIT',
       install_requires=[
         'lxml >= 4.3.0',
-        'suds ; python_version < "3"',
-        'suds-jurko ; python_version >= "3.0"',
         'pyVmomi >= 6.7',
         'vapi-runtime @ file://localhost/{}/lib/vapi-runtime/vapi_runtime-2.25.0-py2.py3-none-any.whl'.format(os.getcwd()),
 	  'vapi-client-bindings @ file://localhost/{}/lib/vapi-client-bindings/vapi_client_bindings-3.6.0-py2.py3-none-any.whl'.format(os.getcwd()),


### PR DESCRIPTION
It looks like you don't really need `suds` or `suds-jurko`. `grep -R suds lib tests` doesn't find anything...

Fixes #286 