### PR TITLE
Add "py_modules" to setup.py, to fix incompatibility with Setuptools in Version 61 and 62

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='vSphere Automation SDK',
       url='https://github.com/vmware/vsphere-automation-sdk-python',
       author='VMware, Inc.',
       license='MIT',
+      py_modules=["lib"],
       install_requires=[
         'lxml >= 4.3.0',
         'pyVmomi >= 6.7',


### PR DESCRIPTION
This fixes an incompatibility with Setuptools in Version 61 and 62, see the Issue:
https://github.com/vmware/vsphere-automation-sdk-python/issues/303

For more Information on the py_modules option, check out:
https://docs.python.org/3/distutils/setupscript.html#listing-individual-modules

Thank you all for the great work on the vsphere python sdk!
