### PR TITLE
Rename the package in setup.py to follow PEP8 conventions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-setup(name='vSphere Automation SDK',
+setup(name='vsphere-automation-sdk-python',
       version='1.80.0',
       description='VMware vSphere Automation SDK for Python',
       url='https://github.com/vmware/vsphere-automation-sdk-python',


### PR DESCRIPTION
Rename the package in setup.py to follow PEP8 conventions https://peps.python.org/pep-0008/#package-and-module-names

Signed-off-by: Tohar Braun <tohar@orca.security>