### PR TITLE
Rename the package in setup.py to follow PEP8 conventions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-setup(name='vSphere Automation SDK',
+setup(name='vsphere-automation-sdk',
       version='1.82.0',
       description='VMware vSphere Automation SDK for Python',
       url='https://github.com/vmware/vsphere-automation-sdk-python',


### PR DESCRIPTION
Following PEP8 guidelines, rename the package in setup.py
Signed-off-by: shweta purohit <spurohit@vmware.com>