### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/samples/vmc/draas/deploy_additional_instance.py
+++ b/samples/vmc/draas/deploy_additional_instance.py
@@ -84,7 +84,7 @@ class DeployAdditionalInstance(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(task_client=self.vmc_client.draas.Task,
                       org_id=self.org_id,
@@ -103,7 +103,7 @@ class DeployAdditionalInstance(object):
             except InvalidRequest as e:
                 # Convert InvalidRequest to ErrorResponse to get error message
                 error_response = e.data.convert_to(ErrorResponse)
-                raise Exception(error_response.error_messages)
+                raise Exception(error_response.error_messages) from e
 
             wait_for_task(task_client=self.vmc_client.draas.Task,
                           org_id=self.org_id,

--- a/samples/vmc/draas/site_recovery_activation_ops.py
+++ b/samples/vmc/draas/site_recovery_activation_ops.py
@@ -70,7 +70,7 @@ class SiteRecoveryActivationOperations(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(task_client=self.vmc_client.draas.Task,
                       org_id=self.org_id,
@@ -87,7 +87,7 @@ class SiteRecoveryActivationOperations(object):
             except InvalidRequest as e:
                 # Convert InvalidRequest to ErrorResponse to get error message
                 error_response = e.data.convert_to(ErrorResponse)
-                raise Exception(error_response.error_messages)
+                raise Exception(error_response.error_messages) from e
 
             wait_for_task(task_client=self.vmc_client.draas.Task,
                           org_id=self.org_id,

--- a/samples/vmc/sddc/add_remove_hosts.py
+++ b/samples/vmc/sddc/add_remove_hosts.py
@@ -83,7 +83,7 @@ class AddRemoveHosts(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(task_client=self.vmc_client.orgs.Tasks,
                       org_id=self.org_id,
@@ -103,7 +103,7 @@ class AddRemoveHosts(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(task_client=self.vmc_client.orgs.Tasks,
                       org_id=self.org_id,

--- a/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
+++ b/samples/vmc/sddc/connect_to_vsphere_with_default_sddc_password.py
@@ -59,7 +59,7 @@ class ConnectTovSphereWithDefaultCredentials(object):
             sddc = vmc_client.orgs.Sddcs.get(self.org_id, self.sddc_id)
         except NotFound as e:
             error_response = e.data.convert_to(ErrorResponse)
-            raise ValueError(error_response.error_messages)
+            raise ValueError(error_response.error_messages) from e
 
         # Get VC hostname
         server = parse.urlparse(sddc.resource_config.vc_url).hostname

--- a/samples/vmc/sddc/sddc_crud.py
+++ b/samples/vmc/sddc/sddc_crud.py
@@ -155,7 +155,7 @@ class CreateDeleteSDDC(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(
             task_client=self.vmc_client.orgs.Tasks,
@@ -187,7 +187,7 @@ class CreateDeleteSDDC(object):
         except InvalidRequest as e:
             # Convert InvalidRequest to ErrorResponse to get error message
             error_response = e.data.convert_to(ErrorResponse)
-            raise Exception(error_response.error_messages)
+            raise Exception(error_response.error_messages) from e
 
         wait_for_task(
             task_client=self.vmc_client.orgs.Tasks,


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.